### PR TITLE
Add removing of libdfp-test-ulps.h

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -460,6 +460,7 @@ clean:
 	rm -f $(addsuffix .out,$(libdfp_tests))
 	rm -f $(addsuffix .conf,$(libdfp_tests))
 	rm -f $(libdfp_tests)
+	rm -f libdfp-test-ulps.h
 	rm -f $(top_builddir)/$(dfp_backend)/*.o
 	rm -f $(top_builddir)/$(dfp_backend)/*.a
 


### PR DESCRIPTION
Makefile misses that and thus make clean and make distclean do not clean everything
properly