### PR TITLE
Fixes cross_compilation variable substitution

### DIFF
--- a/configure
+++ b/configure
@@ -621,6 +621,7 @@ with_dfp
 mzarch
 dfp_backend
 enable_decimal_float
+cross_compiling
 host_os
 host_vendor
 host_cpu
@@ -1979,6 +1980,9 @@ fi
 #if test "$host_cpi" != "$target_cpu"; then
 #  AC_MSG_ERROR([${PACKAGE_NAME} does not yet support cross-compliation.])
 #fi
+
+# Cross-compilation detection variable substitution
+
 
 # PowerPC[64] defaults to DPD encoded DFP.  x86[_64] defaults to BID encoded DFP.
 default_encoding=

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,9 @@ fi
 #  AC_MSG_ERROR([${PACKAGE_NAME} does not yet support cross-compliation.])
 #fi
 
+# Cross-compilation detection variable substitution
+AC_SUBST(cross_compiling)
+
 # PowerPC[64] defaults to DPD encoded DFP.  x86[_64] defaults to BID encoded DFP.
 default_encoding=
 case "$host_cpu" in


### PR DESCRIPTION
The variable 'cross_compilation' was not substituted by 'configure', although configure is able to determine its value. This commit adds the variable 'cross_compilation' to 'ac_subst_vars'.