### PR TITLE
Honor value passed through --docdir

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,7 +9,7 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 libdir = @libdir@
 includedir = @includedir@
-docdir =
+docdir = @docdir@
 
 # Where to install the library and object files.
 ifndef libdir


### PR DESCRIPTION
The configure script does not honor the value passed through --docdir, because
Makefile.in is missing the substitution variable @docdir@

This commit adds such variable, thus causing --docdir to be honored