### PR TITLE
Fix configure when --with-cpu not supplied

### DIFF
--- a/configure
+++ b/configure
@@ -4244,6 +4244,30 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 
+# If building for a soft dfp, we must explicitly
+# prevent the compiler from emitting hardware
+# instructions. Otherwise, unexpected behavior
+# will occur.
+#
+# Test to the toolchain to see if it supports the
+# option to disable hard dfp, and if so, disable it.
+# This should work for s390 and power.
+if test "$with_dfp" == "no"; then
+  cflags_tmp="$CFLAGS"
+  CFLAGS="$CFLAGS -mno-hard-dfp"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+else
+  CFLAGS="$cflags_tmp"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_dfp" >&5
 $as_echo "$with_dfp" >&6; }
 

--- a/configure
+++ b/configure
@@ -4184,22 +4184,59 @@ else
 
   case "$host_cpu" in
   powerpc*)
+    # Test successively newer processors and select the
+    # best implementation.
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-      #ifdef _ARCH_PWR6
-      # define SUCCESS 1
-      #else
+      #ifndef _ARCH_PWR6
       # error "Support for hardware dfp isn't available"
       #endif
 
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  with_dfp=yes
+  with_dfp=yes; submachine=power6
 else
   with_dfp=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext ;;
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #ifndef _ARCH_PWR6X
+      # error "POWER6X not supported"
+      #endif
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  submachine=power6x
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #ifndef _ARCH_PWR7
+      # error "POWER7 not supported"
+      #endif
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  submachine=power7
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #ifndef _ARCH_PWR8
+      # error "POWER8 not supported"
+      #endif
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  submachine=power8
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+    ;;
   *)
     with_dfp=no ;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,21 @@ AC_ARG_WITH([cpu],
     with_dfp=no ;;
   esac
 ])
+
+# If building for a soft dfp, we must explicitly
+# prevent the compiler from emitting hardware
+# instructions. Otherwise, unexpected behavior
+# will occur.
+#
+# Test to the toolchain to see if it supports the
+# option to disable hard dfp, and if so, disable it.
+# This should work for s390 and power.
+if test "$with_dfp" == "no"; then
+  cflags_tmp="$CFLAGS"
+  CFLAGS="$CFLAGS -mno-hard-dfp"
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[]])],[],[CFLAGS="$cflags_tmp"])
+fi
+
 AC_SUBST(with_dfp)
 AC_MSG_RESULT($with_dfp)
 

--- a/configure.ac
+++ b/configure.ac
@@ -220,13 +220,29 @@ AC_ARG_WITH([cpu],
 ],[
   case "$host_cpu" in
   powerpc*)
+    # Test successively newer processors and select the
+    # best implementation.
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-      #ifdef _ARCH_PWR6
-      # define SUCCESS 1
-      #else
+      #ifndef _ARCH_PWR6
       # error "Support for hardware dfp isn't available"
       #endif
-      ]])], [with_dfp=yes], [with_dfp=no]) ;;
+      ]])], [with_dfp=yes; submachine=power6], [with_dfp=no])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+      #ifndef _ARCH_PWR6X
+      # error "POWER6X not supported"
+      #endif
+      ]])], [submachine=power6x], [])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+      #ifndef _ARCH_PWR7
+      # error "POWER7 not supported"
+      #endif
+      ]])], [submachine=power7], [])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+      #ifndef _ARCH_PWR8
+      # error "POWER8 not supported"
+      #endif
+      ]])], [submachine=power8], [])
+    ;;
   *)
     with_dfp=no ;;
   esac


### PR DESCRIPTION
This will now attempt to use the newest CPU architecture available
from the compiler, and prevent a degenerate case whereby hardware
dfp is supported, but a specific PPC machine is not selected.