### PR TITLE
Final set of patches for DPD TI mode support

### DIFF
--- a/base-math/Makefile
+++ b/base-math/Makefile
@@ -49,4 +49,6 @@ libdfp_files += addsd3 adddd3 addtd3 \
 
 libdfp_ti_files += fixsdti fixddti \
 		   fixunssdti fixunsddti \
-		   floattitd floatunstitd
+		   floattitd floatunstitd \
+		   floattidd floatunstidd \
+		   floattisd floatunstisd

--- a/base-math/floattidd.c
+++ b/base-math/floattidd.c
@@ -1,10 +1,10 @@
-/* Convert a unsigned 128-bit binary integer into nearest representable
-   IEEE754R 128-bit Densely Packed Decimal Floating-point (DFP).
+/* Convert a signed 128-bit binary integer into nearest representable
+   IEEE754R 64-bit Densely Packed Decimal Floating-point (DFP).
 
    Copyright (C) 2015 Free Software Foundation, Inc.
    This file is part of the Decimal Floating Point C Library.
 
-   Contributed by Steven Munroe (munroesj@linux.vnet.ibm.com)
+   Contributed by Paul E. Murphy (murphyp@linux.vnet.ibm.com)
 
    The Decimal Floating Point C Library is free software; you can
    redistribute it and/or modify it under the terms of the GNU Lesser
@@ -22,9 +22,7 @@
 
    Please see dfp/COPYING.txt for more information.  */
 
-#define UNSIGNED  1
-#define FUNC floatunstitd
-#define RET_TYPE _Decimal128
-#define RET_SIZE 128
-
+#define FUNC floattidd
+#define RET_TYPE _Decimal64
+#define RET_SIZE 64
 #include "floattitd.c"

--- a/base-math/floattisd.c
+++ b/base-math/floattisd.c
@@ -1,10 +1,10 @@
-/* Convert a unsigned 128-bit binary integer into nearest representable
-   IEEE754R 128-bit Densely Packed Decimal Floating-point (DFP).
+/* Convert a signed 128-bit binary integer into nearest representable
+   IEEE754R 32-bit Densely Packed Decimal Floating-point (DFP).
 
    Copyright (C) 2015 Free Software Foundation, Inc.
    This file is part of the Decimal Floating Point C Library.
 
-   Contributed by Steven Munroe (munroesj@linux.vnet.ibm.com)
+   Contributed by Paul E. Murphy (murphyp@linux.vnet.ibm.com)
 
    The Decimal Floating Point C Library is free software; you can
    redistribute it and/or modify it under the terms of the GNU Lesser
@@ -22,9 +22,7 @@
 
    Please see dfp/COPYING.txt for more information.  */
 
-#define UNSIGNED  1
-#define FUNC floatunstitd
-#define RET_TYPE _Decimal128
-#define RET_SIZE 128
-
+#define FUNC floattisd
+#define RET_TYPE _Decimal32
+#define RET_SIZE 32
 #include "floattitd.c"

--- a/base-math/floatunstidd.c
+++ b/base-math/floatunstidd.c
@@ -1,10 +1,10 @@
-/* Convert a unsigned 128-bit binary integer into nearest representable
-   IEEE754R 128-bit Densely Packed Decimal Floating-point (DFP).
+/* Convert an unsigned 128-bit binary integer into nearest representable
+   IEEE754R 64-bit Densely Packed Decimal Floating-point (DFP).
 
    Copyright (C) 2015 Free Software Foundation, Inc.
    This file is part of the Decimal Floating Point C Library.
 
-   Contributed by Steven Munroe (munroesj@linux.vnet.ibm.com)
+   Contributed by Paul E. Murphy (murphyp@linux.vnet.ibm.com)
 
    The Decimal Floating Point C Library is free software; you can
    redistribute it and/or modify it under the terms of the GNU Lesser
@@ -22,9 +22,8 @@
 
    Please see dfp/COPYING.txt for more information.  */
 
-#define UNSIGNED  1
-#define FUNC floatunstitd
-#define RET_TYPE _Decimal128
-#define RET_SIZE 128
-
+#define FUNC floatunstidd
+#define RET_TYPE _Decimal64
+#define RET_SIZE 64
+#define UNSIGNED
 #include "floattitd.c"

--- a/base-math/floatunstisd.c
+++ b/base-math/floatunstisd.c
@@ -1,10 +1,10 @@
-/* Convert a unsigned 128-bit binary integer into nearest representable
-   IEEE754R 128-bit Densely Packed Decimal Floating-point (DFP).
+/* Convert an unsigned 128-bit binary integer into nearest representable
+   IEEE754R 32-bit Densely Packed Decimal Floating-point (DFP).
 
    Copyright (C) 2015 Free Software Foundation, Inc.
    This file is part of the Decimal Floating Point C Library.
 
-   Contributed by Steven Munroe (munroesj@linux.vnet.ibm.com)
+   Contributed by Paul E. Murphy (murphyp@linux.vnet.ibm.com)
 
    The Decimal Floating Point C Library is free software; you can
    redistribute it and/or modify it under the terms of the GNU Lesser
@@ -22,9 +22,8 @@
 
    Please see dfp/COPYING.txt for more information.  */
 
-#define UNSIGNED  1
-#define FUNC floatunstitd
-#define RET_TYPE _Decimal128
-#define RET_SIZE 128
-
+#define FUNC floatunstisd
+#define RET_TYPE _Decimal32
+#define RET_SIZE 32
+#define UNSIGNED
 #include "floattitd.c"

--- a/include/dfpacc.h
+++ b/include/dfpacc.h
@@ -185,16 +185,16 @@ _Decimal128 __BACKEND_(floatunssitd) (unsigned int);
 hidden_proto_enc (floatunssitd)
 
 #if defined(HAVE_UINT128_T) || defined(HAVE_INT128)
-_Decimal64 __BACKEND_(floatunstidd) (UINT128);
-hidden_proto_enc (floatunstidd)
 _Decimal32 __BACKEND_(floatunstisd) (UINT128);
 hidden_proto_enc (floatunstisd)
+_Decimal64 __BACKEND_(floatunstidd) (UINT128);
+hidden_proto_enc (floatunstidd)
 _Decimal128 __BACKEND_(floatunstitd) (UINT128);
 hidden_proto_enc (floatunstitd)
 
-_Decimal128 __BACKEND_(floattisd) (INT128);
+_Decimal32 __BACKEND_(floattisd) (INT128);
 hidden_proto_enc (floattisd)
-_Decimal128 __BACKEND_(floattidd) (INT128);
+_Decimal64 __BACKEND_(floattidd) (INT128);
 hidden_proto_enc (floattidd)
 _Decimal128 __BACKEND_(floattitd) (INT128);
 hidden_proto_enc (floattitd)

--- a/sysdeps/bid/Versions
+++ b/sysdeps/bid/Versions
@@ -24,7 +24,11 @@ libdfp {
 
   LIBDFP_1.0.13 {
     __bid_floattitd;
+    __bid_floattidd;
+    __bid_floattisd;
     __bid_floatunstitd;
+    __bid_floatunstidd;
+    __bid_floatunstisd;
     __bid_fixunssdti;
     __bid_fixunsddti;
     __bid_fixsdti;

--- a/sysdeps/bid/libdfp.abilist
+++ b/sysdeps/bid/libdfp.abilist
@@ -310,7 +310,11 @@ LIBDFP_1.0.13
  __bid_fixsdti F
  __bid_fixunsddti F
  __bid_fixunssdti F
+ __bid_floattidd F
+ __bid_floattisd F
  __bid_floattitd F
+ __bid_floatunstidd F
+ __bid_floatunstisd F
  __bid_floatunstitd F
 LIBDFP_1.0.2
  LIBDFP_1.0.2 A

--- a/sysdeps/bid/symbol-hacks.h
+++ b/sysdeps/bid/symbol-hacks.h
@@ -30,7 +30,11 @@ asm ("__bid_floatsidd  = __GI___bid_floatsidd");
 asm ("__bid_floatditd  = __GI___bid_floatditd");
 asm ("__bid_floatsitd  = __GI___bid_floatsitd");
 asm ("__bid_floatdidd  = __GI___bid_floatdidd");
+asm ("__bid_floatdisd  = __GI___bid_floatdisd");
 asm ("__bid_floatsisd  = __GI___bid_floatsisd");
+
+asm ("__bid_floatunsdisd  = __GI___bid_floatunsdisd");
+asm ("__bid_floatunsdidd  = __GI___bid_floatunsdidd");
 
 #if HAVE_UINT128_T
 asm ("__bid_floattitd  = __GI___bid_floattitd");

--- a/sysdeps/dpd/Versions
+++ b/sysdeps/dpd/Versions
@@ -41,7 +41,11 @@ libdfp {
     __dpd_fixunsddti;
     __dpd_fixunssdti;
     __dpd_floattitd;
+    __dpd_floattidd;
+    __dpd_floattisd;
     __dpd_floatunstitd;
+    __dpd_floatunstidd;
+    __dpd_floatunstisd;
   }
 
 }

--- a/sysdeps/dpd/symbol-hacks.h
+++ b/sysdeps/dpd/symbol-hacks.h
@@ -29,9 +29,12 @@ asm ("__dpd_floatsidd  = __GI___dpd_floatsidd");
 asm ("__dpd_floatditd  = __GI___dpd_floatditd");
 asm ("__dpd_floatsitd  = __GI___dpd_floatsitd");
 asm ("__dpd_floatdidd  = __GI___dpd_floatdidd");
+asm ("__dpd_floatdisd  = __GI___dpd_floatdisd");
 asm ("__dpd_floatsisd  = __GI___dpd_floatsisd");
 
 asm ("__dpd_floatunsditd  = __GI___dpd_floatditd");
+asm ("__dpd_floatunsdidd  = __GI___dpd_floatdidd");
+asm ("__dpd_floatunsdisd  = __GI___dpd_floatdisd");
 
 #ifdef HAVE_UINT128_T
 asm ("__dpd_floattitd  = __GI___dpd_floattitd");

--- a/sysdeps/powerpc/dfpu/convert_helpers.h
+++ b/sysdeps/powerpc/dfpu/convert_helpers.h
@@ -1,0 +1,48 @@
+/* Prototypes for assisting converting larger numbers.
+ 
+   Copyright (C) 2015 Free Software Foundation, Inc.
+
+   Author(s): Paul E. Murphy <murphyp@linux.vnet.ibm.com>
+
+   The Decimal Floating Point C Library is free software; you can
+   redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License version 2.1.
+
+   The Decimal Floating Point C Library is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+   the GNU Lesser General Public License version 2.1 for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License version 2.1 along with the Decimal Floating Point C Library;
+   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+   Suite 330, Boston, MA 02111-1307 USA.
+
+   Please see dfp/COPYING.txt for more information.  */
+
+#ifndef _CONVERTHELPERS_
+#define _CONVERTHELPERS_
+
+#include "fenv_libdfp.h"
+
+#define COMBINE_AND_TRUNC(a,b,c,SIZE)                                         \
+static inline _Decimal ## SIZE                                                \
+combine_and_truncd ## SIZE (_Decimal128 hi, _Decimal128 mid, _Decimal128 low) \
+{                                                                             \
+  _Decimal128 result;                                                         \
+  fenv_t rnd = fegetenv_register();                                           \
+  asm volatile ("mtfsfi 7, 7, 1"); /* Enforce round to prep for shorter.  */  \
+  hi = __builtin_dscliq (hi, 17);                                             \
+  result = (hi + mid) * 1e17DL;                                               \
+  /* This is a hack. We need to ensure this and above happens under           \
+     the correct rounding mode. */                                            \
+  asm volatile ("daddq %0,%1,%2" : "=f" (result) : "f" (result), "f" (low) ) ;\
+  fesetenv_register (rnd);                                                    \
+  return result; /* Implicitly round result into return type.  */             \
+}
+
+/* Define combine_and_truncd32 and combine_and_truncd64.  */
+COMBINE_AND_TRUNC(a,b,c,32)
+COMBINE_AND_TRUNC(a,b,c,64)
+
+#endif /* _CONVERTHELPERS_ */

--- a/sysdeps/powerpc/dfpu/libdfp.abilist
+++ b/sysdeps/powerpc/dfpu/libdfp.abilist
@@ -312,7 +312,11 @@ LIBDFP_1.0.13
  __dpd_fixunsddti F
  __dpd_fixunssdti F
  __dpd_fixunstdti F
+ __dpd_floattidd F
+ __dpd_floattisd F
  __dpd_floattitd F
+ __dpd_floatunstidd F
+ __dpd_floatunstisd F
  __dpd_floatunstitd F
 LIBDFP_1.0.2
  LIBDFP_1.0.2 A

--- a/sysdeps/powerpc/fpu/libdfp.abilist
+++ b/sysdeps/powerpc/fpu/libdfp.abilist
@@ -312,7 +312,11 @@ LIBDFP_1.0.13
  __dpd_fixunsddti F
  __dpd_fixunssdti F
  __dpd_fixunstdti F
+ __dpd_floattidd F
+ __dpd_floattisd F
  __dpd_floattitd F
+ __dpd_floatunstidd F
+ __dpd_floatunstisd F
  __dpd_floatunstitd F
 LIBDFP_1.0.2
  LIBDFP_1.0.2 A

--- a/sysdeps/powerpc/powerpc32/power6/fpu/trunctdsd2.S
+++ b/sysdeps/powerpc/powerpc32/power6/fpu/trunctdsd2.S
@@ -28,8 +28,11 @@
 	.machine	"power6"
 /* _Decimal32 __dpd_trunctdsd2 (_Decimal128 x)  */
 ENTRY (__dpd_trunctdsd2)
-	drdpq	fp0,fp2	/* Round result to _Decimal64. */
-	drsp	fp1,fp0	/* Round result to _Decimal32. */
+	mffs    fp4     /* Save current rounding mode.  */
+	mtfsfi  7, 7, 1 /* Set round to prepare for shorter.  */
+	drdpq	fp0,fp2	/* Initial round to _Decimal64.  */
+	mtfsf   0xff,fp4,1,0 /* Restore previous rounding mode.  */
+	drsp	fp1,fp0	/* Round result to _Decimal32.  */
 	blr
 END (__dpd_trunctdsd2)
 hidden_def (__dpd_trunctdsd2)

--- a/sysdeps/powerpc/powerpc64/power6/fpu/trunctdsd2.S
+++ b/sysdeps/powerpc/powerpc64/power6/fpu/trunctdsd2.S
@@ -28,8 +28,11 @@
 	.machine	"power6"
 /* _Decimal32 __dpd_trunctdsd2 (_Decimal128 x)  */
 ENTRY (__dpd_trunctdsd2)
-	drdpq	fp0,fp2	/* Round result to _Decimal64. */
-	drsp	fp1,fp0	/* Round result to _Decimal32. */
+	mffs    fp4     /* Save current rounding mode.  */
+	mtfsfi  7, 7, 1 /* Set round to prepare for shorter.  */
+	drdpq	fp0,fp2	/* Initial round to _Decimal64.  */
+	mtfsf   0xff,fp4,1,0 /* Restore previous rounding mode.  */
+	drsp	fp1,fp0	/* Round result to _Decimal32.  */
 	blr
 END (__dpd_trunctdsd2)
 hidden_def (__dpd_trunctdsd2)

--- a/sysdeps/soft-dfp/Makefile
+++ b/sysdeps/soft-dfp/Makefile
@@ -1,3 +1,4 @@
 # base-math/Makefile defines all of the arithmetic, conversion, and comparison
 # functions.
-libdfp_files += decroundtls
+libdfp_files += decroundtls \
+		candtruncd32 candtruncd64

--- a/sysdeps/soft-dfp/candtruncd32.c
+++ b/sysdeps/soft-dfp/candtruncd32.c
@@ -1,0 +1,88 @@
+/* Take 3 _Decimal128 numbers spanning 39 digits and
+   convert them into one properly rounding _Decimal32 value.
+
+   This is meant to be used internally to assist in rounding
+   __int128 values to _Decimal32/64.
+
+   Copyright (C) 2015 Free Software Foundation, Inc.
+
+   This file is part of the Decimal Floating Point C Library.
+
+   Author(s): Paul E. Murphy <murphyp@linux.vnet.ibm.com>
+
+   The Decimal Floating Point C Library is free software; you can
+   redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License version 2.1.
+
+   The Decimal Floating Point C Library is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+   the GNU Lesser General Public License version 2.1 for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License version 2.1 along with the Decimal Floating Point C Library;
+   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+   Suite 330, Boston, MA 02111-1307 USA.
+
+   Please see libdfp/COPYING.txt for more information.  */
+
+/* This will take at most 39 digits.  This should always be 39
+   for this function.  It must defined before including this
+   file as decimal*.h will attempt to define it.  */
+#define DECNUMDIGITS 39
+
+#ifndef _DECIMAL_SIZE
+#  define _DECIMAL_SIZE 32
+#  include <decimal32.h>
+#  define FUNC_NAME combine_and_truncd32
+#endif
+
+#include "decimal128.h"
+#include "dfptypeconv128.h"
+#include "dfpmacro.h"
+
+#include "convert_helpers.h"
+
+#include <stdio.h>
+
+DEC_TYPE
+FUNC_NAME (_Decimal128 hi, _Decimal128 mid, _Decimal128 low)
+{
+  DEC_TYPE result;
+
+  /*  hi = m_hi *  10^34
+   * mid = m_mid * 10^17
+   * low = m_low * 10^0
+   *
+   * Note, m_hi is only at most 5 digits for int128.
+   */
+  decNumber dn_hi, dn_mid, dn_low, dn_result;
+  decNumber dn_hi_s, dn_mid_s, dn_result_s;
+  decNumber dn_17, dn_34;
+  decContext context;
+
+  decContextDefault (&context, DEC_INIT_DECIMAL128);
+  /* Hack, we're using 39 digits here. */
+  context.digits = 39;
+
+  decNumberFromInt32(&dn_17, 17);
+  decNumberFromInt32(&dn_34, 34);
+
+  __DECIMAL_TO_DECNUMBER (&hi,  &dn_hi,  128);
+  __DECIMAL_TO_DECNUMBER (&mid, &dn_mid, 128);
+  __DECIMAL_TO_DECNUMBER (&low, &dn_low, 128);
+
+  /* Rotate addends into proper position.  */
+  decNumberShift(&dn_hi_s,&dn_hi,&dn_34,&context);
+  decNumberShift(&dn_mid_s,&dn_mid,&dn_17,&context);
+
+  /* Sum the three components.  */
+  decNumberAdd(&dn_result_s, &dn_hi_s, &dn_mid_s, &context);
+  decNumberAdd(&dn_result, &dn_result_s, &dn_low, &context);
+
+  /* Convert to the destination format.  */
+  FUNC_CONVERT_FROM_DN (&dn_result, &result, &context);
+
+  /* Don't care about exceptions here... I don't think.  */
+  return result;
+}

--- a/sysdeps/soft-dfp/candtruncd64.c
+++ b/sysdeps/soft-dfp/candtruncd64.c
@@ -1,10 +1,14 @@
-/* Convert a unsigned 128-bit binary integer into nearest representable
-   IEEE754R 128-bit Densely Packed Decimal Floating-point (DFP).
+/* Take 3 _Decimal128 numbers spanning 39 digits and
+   convert them into one properly rounding _Decimal64 value.
+
+   This is meant to be used internally to assist in rounding
+   __int128 values to _Decimal32/64.
 
    Copyright (C) 2015 Free Software Foundation, Inc.
+
    This file is part of the Decimal Floating Point C Library.
 
-   Contributed by Steven Munroe (munroesj@linux.vnet.ibm.com)
+   Author(s): Paul E. Murphy <murphyp@linux.vnet.ibm.com>
 
    The Decimal Floating Point C Library is free software; you can
    redistribute it and/or modify it under the terms of the GNU Lesser
@@ -20,11 +24,15 @@
    if not, write to the Free Software Foundation, Inc., 59 Temple Place,
    Suite 330, Boston, MA 02111-1307 USA.
 
-   Please see dfp/COPYING.txt for more information.  */
+   Please see libdfp/COPYING.txt for more information.  */
 
-#define UNSIGNED  1
-#define FUNC floatunstitd
-#define RET_TYPE _Decimal128
-#define RET_SIZE 128
+/* This will take at most 39 digits.  This should always be 39
+   for this function.  It must defined before including this
+   file as decimal*.h will attempt to define it.  */
+#define DECNUMDIGITS 39
 
-#include "floattitd.c"
+#define _DECIMAL_SIZE 64
+#include <decimal64.h>
+#define FUNC_NAME combine_and_truncd64
+
+#include "candtruncd32.c"

--- a/sysdeps/soft-dfp/convert_helpers.h
+++ b/sysdeps/soft-dfp/convert_helpers.h
@@ -1,10 +1,8 @@
-/* Convert a unsigned 128-bit binary integer into nearest representable
-   IEEE754R 128-bit Densely Packed Decimal Floating-point (DFP).
-
+/* Prototypes for assisting converting larger numbers.
+ 
    Copyright (C) 2015 Free Software Foundation, Inc.
-   This file is part of the Decimal Floating Point C Library.
 
-   Contributed by Steven Munroe (munroesj@linux.vnet.ibm.com)
+   Author(s): Paul E. Murphy <murphyp@linux.vnet.ibm.com>
 
    The Decimal Floating Point C Library is free software; you can
    redistribute it and/or modify it under the terms of the GNU Lesser
@@ -22,9 +20,13 @@
 
    Please see dfp/COPYING.txt for more information.  */
 
-#define UNSIGNED  1
-#define FUNC floatunstitd
-#define RET_TYPE _Decimal128
-#define RET_SIZE 128
+#ifndef _CONVERTHELPERS_
+#define _CONVERTHELPERS_
 
-#include "floattitd.c"
+_Decimal64
+combine_and_truncd64 (_Decimal128 hi, _Decimal128 mid, _Decimal128 low);
+
+_Decimal32
+combine_and_truncd32 (_Decimal128 hi, _Decimal128 mid, _Decimal128 low);
+
+#endif /* _CONVERTHELPERS_ */

--- a/tests/test-float.c
+++ b/tests/test-float.c
@@ -52,7 +52,7 @@
 
 /* TODO: For now, BID does not have dpd conversions.  */
 #ifndef __DECIMAL_BID_FORMAT__
-#define HAS_TI 1
+#define HAS_TITD 1
 #endif
 
 #define _WANT_VC 1		/* Pick up the _VC_P(x,y,fmt) macro.  */
@@ -69,39 +69,86 @@
 #include "../sysdeps/dpd/dpd-private.c"
 #endif
 
-typedef struct
-{
-  const char *format;		/* Expected value printf format.  */
-  int uns;			/* Signed or unsigned conversion.  */
-  int line;
-  char const *x;		/* Stringified INT128 input value.  */
-  _Decimal128 e;		/* Expected result.  */
-} d128_type;
+#define TEST_STRUCT(SIZE)                                              \
+struct                                                                 \
+{                                                                      \
+  const char *format;		/* Expected value printf format.  */   \
+  int uns;			/* Signed or unsigned conversion.  */  \
+  int line;                                                            \
+  char const *x;		/* Stringified INT128 input value.  */ \
+  _Decimal##SIZE e;		/* Expected result.  */                \
+} d##SIZE[]
 
-static d128_type d128[] = {
-#if HAS_TI
+TEST_STRUCT(128) = {
+#if HAS_TITD
   {"%DDe", 0, __LINE__, "0", 0.DL},
   {"%DDe", 0, __LINE__, "1", 1.DL},
   {"%DDe", 0, __LINE__, "-1", -1.DL},
   {"%DDe", 0, __LINE__, "170141183460469231731687303715884100000",
-   170141183460469231731687303715884100000.DL},
+                         170141183460469231731687303715884100000.DL},
   {"%DDe", 0, __LINE__, "170141183460469231731687303715884100001",
-   170141183460469231731687303715884100000.DL},
+                         170141183460469231731687303715884100000.DL},
   {"%DDe", 0, __LINE__, "-170141183460469231731687303715884100000",
-   -170141183460469231731687303715884100000.DL},
+                         -170141183460469231731687303715884100000.DL},
   {"%DDe", 0, __LINE__, "-100000000000000000", -1e17DL},
   {"%DDe", 0, __LINE__, "100000000000000000", 1e17DL},
 
   /* Unsigned conversions.  */
   {"%DDe", 1, __LINE__, "340282366920938463463374607431768211455",
-   340282366920938463463374607431768200000.DL},
+                         340282366920938463463374607431768200000.DL},
   {"%DDe", 1, __LINE__, "1000000", 1000000.DL},
   {"%DDe", 1, __LINE__, "100000000000000000", 100000000000000000.DL},
   {"%DDe", 1, __LINE__, "0", 0.DL},
 #endif /* HAS_TI */
 };
 
-static int d128_s = sizeof (d128) / sizeof (d128[0]);
+TEST_STRUCT(64) = {
+  {"%De", 0, __LINE__, "0", 0.DD},
+  {"%De", 0, __LINE__, "1", 1.DD},
+  {"%De", 0, __LINE__, "-1", -1.DD},
+  {"%De", 0, __LINE__, "170141183460469231731687303715884100000",
+                        170141183460469231731687303715884100000.DD},
+  {"%De", 0, __LINE__, "170141183460469231731687303715884100001",
+                        170141183460469231731687303715884100000.DD},
+  {"%De", 0, __LINE__, "-170141183460469231731687303715884100000",
+                        -170141183460469231731687303715884100000.DD},
+  {"%De", 0, __LINE__, "-100000000000000000", -1e17DD},
+  {"%De", 0, __LINE__, "100000000000000000", 1e17DD},
+
+  /* Unsigned conversions.  */
+  {"%De", 1, __LINE__, "340282366920938463463374607431768211455",
+                        340282366920938463463374607431768200000.DD},
+  {"%De", 1, __LINE__, "340282366920938463463374607431768211455",
+                        340282366920938463463374607431768200000.DD},
+  {"%De", 1, __LINE__, "1000000", 1000000.DD},
+  {"%De", 1, __LINE__, "100000000000000000", 100000000000000000.DD},
+  {"%De", 1, __LINE__, "0", 0.DD},
+};
+
+TEST_STRUCT(32) = {
+  {"%He", 0, __LINE__, "0", 0.DF},
+  {"%He", 0, __LINE__, "1", 1.DF},
+  {"%He", 0, __LINE__, "-1", -1.DF},
+  {"%He", 0, __LINE__, "170141183460469231731687303715884100000",
+                        170141183460469230000000000000000000000.DF},
+  {"%He", 0, __LINE__, "170141183460469231731687303715884100001",
+                        170141183460469230000000000000000000000.DF},
+  {"%He", 0, __LINE__, "-170141183460469231731687303715884100000",
+                        -170141183460469231731687303715884100000.DF},
+  {"%He", 0, __LINE__, "-100000000000000000", -1e17DF},
+  {"%He", 0, __LINE__, "100000000000000000", 1e17DF},
+
+  /* Unsigned conversions.  */
+  {"%He", 1, __LINE__, "340282366920938463463374607431768211455",
+                        340282370000000000000000000000000000000.DF},
+  {"%He", 1, __LINE__, "340282350000000000000000000000000000001",
+                        340282400000000000000000000000000000000.DF},
+  {"%He", 1, __LINE__, "340282349999999999999999999999999999999",
+                        340282300000000000000000000000000000000.DF},
+  {"%He", 1, __LINE__, "1000000", 1000000.DF},
+  {"%He", 1, __LINE__, "100000000000000000", 100000000000000000.DF},
+  {"%He", 1, __LINE__, "0", 0.DF},
+};
 
 /* Mediocre string to ti/unsti function. */
 static INT128
@@ -125,30 +172,35 @@ intifyti (char const *str)
   return val;
 }
 
+#define RUN_TESTS(SIZE, SUF) \
+  for (i = 0; i < (int)(sizeof (d##SIZE) / sizeof (d##SIZE[0])); ++i) \
+    { \
+      _Decimal ## SIZE x; \
+      char const *fmt; \
+      if (d##SIZE[i].uns) \
+	{ \
+	  fmt = "floatunsti"#SUF" (%s) in: %s:%d\n"; \
+	  UINT128 x_ti = intifyti (d##SIZE[i].x); \
+	  x = x_ti; \
+	} \
+      else \
+	{ \
+	  fmt = "floatti"#SUF"(%s) in: %s:%d\n"; \
+	  INT128 x_ti = intifyti (d##SIZE[i].x); \
+	  x = x_ti; \
+	} \
+      fprintf (stdout, fmt, d##SIZE[i].x, __FILE__, __LINE__); \
+      _VC_P (__FILE__, d##SIZE[i].line, d##SIZE[i].e, x, d##SIZE[i].format); \
+    }
+
 int
 main (void)
 {
   int i;
 
-  for (i = 0; i < d128_s; ++i)
-    {
-      _Decimal128 x;
-      char const *fmt;
-      if (d128[i].uns)
-	{
-	  fmt = "floatunstitd (%s) in: %s:%d\n";
-	  UINT128 x_ti = intifyti (d128[i].x);
-	  x = x_ti;
-	}
-      else
-	{
-	  fmt = "floattitd (%s) in: %s:%d\n";
-	  INT128 x_ti = intifyti (d128[i].x);
-	  x = x_ti;
-	}
-      fprintf (stdout, fmt, d128[i].x, __FILE__, __LINE__);
-      _VC_P (__FILE__, d128[i].line, d128[i].e, x, d128[i].format);
-    }
+  RUN_TESTS (128, td);
+  RUN_TESTS (64, dd);
+  RUN_TESTS (32, sd);
 
   _REPORT ();
 


### PR DESCRIPTION
This implements the float*ti{dd,sd} functions, and fixes a double rounding bug uncovered in trunctdsd2 while testing whether the default rounding mode was working as expected.