### PR TITLE
Fix -Wunused-result warning message in test-amort.c

### DIFF
--- a/tests/test-amort.c
+++ b/tests/test-amort.c
@@ -271,6 +271,7 @@ main (int argc, char *argv[])
   FILE *inputfile;
   char inputfilename[] = "amort.input";
   const char *argv_option;
+  ssize_t r;
 
   table = (tabletype *) malloc (30 * 12 * sizeof (tabletype));
   //printf ("table@%p for %d bytes\n", table, (30 * 12 * sizeof (tabletype)));
@@ -324,7 +325,15 @@ main (int argc, char *argv[])
   numinputs = ftell (inputfile) / sizeof (inputtype);
   rewind (inputfile);
   inputs = malloc (numinputs * sizeof (inputtype));
-  fread (inputs, sizeof (inputtype), numinputs, inputfile);
+
+  r = fread (inputs, sizeof (inputtype), numinputs, inputfile);
+  if (r != numinputs)
+    {
+      printf ("fread() error\n");
+      fclose (inputfile);
+      exit (EXIT_FAILURE);
+    }
+
   fclose (inputfile);
 
   if (*argv_option == 'v')


### PR DESCRIPTION
This patch gets rid of the following message during "make check":

./tests/test-amort.c: In function ‘main’:
./tests/test-amort.c:327:9: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
   fread (inputs, sizeof (inputtype), numinputs, inputfile);
         ^

Fixes issue https://github.com/libdfp/libdfp/issues/42

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>