### PR TITLE
Fix incorrect conversion on overflow.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -324,7 +324,7 @@ $(top_builddir)/libdfp.map: $(top_builddir)/sysd-versions
 GLIBC_LIBS := -lc -lm
 
 libdfp_c_tests = test-printf test-amort test-decode \
-		 test-strtod test-numdigits test-get_digits \
+		 test-strtod test-cast-to-overflow test-numdigits test-get_digits \
 		 test-fenv test-bfp-conversions test-type-conversions test-wchar \
 		 test-getexp test-setexp test-left_justify \
 		 test-fpclassify-d32 test-fpclassify-d64 test-fpclassify-d128 \

--- a/base-math/truncdddf.c
+++ b/base-math/truncdddf.c
@@ -28,6 +28,9 @@
 #define DEST 64
 #define NAME trunc
 
+#include <float.h>
+#include <fenv.h>
+
 #include "dfpacc.h"
 #include "convert.h"
 #include "convert_helpers.h"
@@ -49,7 +52,19 @@ CONVERT_WRAPPER(
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_OVERFLOW|FE_INEXACT);
-	    return SIGNBIT(a) ? -INFINITY : INFINITY;
+
+	    switch (fegetround())
+	      {
+	        case FE_TOWARDZERO:
+	          return SIGNBIT(a) ? -DBL_MAX : DBL_MAX;
+	        case FE_DOWNWARD:
+	          return SIGNBIT(a) ? -INFINITY : DBL_MAX;
+	        case FE_UPWARD:
+	          return SIGNBIT(a) ? -DBL_MAX : INFINITY;
+	        case FE_TONEAREST:
+	        default:
+	          return SIGNBIT(a) ? -INFINITY : INFINITY;
+	      }
 	  }
 	else if (exp < -BINPOWOF10_LIMIT)	/* Obvious underflow.  */
 	  {

--- a/base-math/trunctdsf.c
+++ b/base-math/trunctdsf.c
@@ -28,6 +28,9 @@
 #define DEST 32
 #define NAME trunc
 
+#include <float.h>
+#include <fenv.h>
+
 #include "dfpacc.h"
 #include "convert.h"
 #include "convert_helpers.h"
@@ -46,7 +49,19 @@ CONVERT_WRAPPER(
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_OVERFLOW|FE_INEXACT);
-	    return SIGNBIT(a) ? -INFINITY : INFINITY;
+
+	    switch (fegetround())
+	      {
+	        case FE_TOWARDZERO:
+	          return SIGNBIT(a) ? -FLT_MAX : FLT_MAX;
+	        case FE_DOWNWARD:
+	          return SIGNBIT(a) ? -INFINITY :FLT_MAX;
+	        case FE_UPWARD:
+	          return SIGNBIT(a) ? -FLT_MAX : INFINITY;
+	        case FE_TONEAREST:
+	        default:
+	          return SIGNBIT(a) ? -INFINITY : INFINITY;
+	      }
 	  }
 	else if (exp < -39)	/* Obvious underflow. */
 	  {

--- a/tests/test-cast-to-overflow.c
+++ b/tests/test-cast-to-overflow.c
@@ -1,0 +1,97 @@
+/* Test trucate cast Decimal -> Binary overflow.
+
+   Copyright (C) 2017 Free Software Foundation, Inc.
+
+   This file is part of the Decimal Floating Point C Library.
+
+   Author: Rogerio Alves <rogealve@br.ibm.com>
+
+   The Decimal Floating Point C Library is free software; you can
+   redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License version 2.1.
+
+   The Decimal Floating Point C Library is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+   the GNU Lesser General Public License version 2.1 for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License version 2.1 along with the Decimal Floating Point C Library;
+   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+   Suite 330, Boston, MA 02111-1307 USA.
+
+   Please see libdfp/COPYING.txt for more information.  */
+
+#ifndef __STDC_WANT_DEC_FP__
+#define __STDC_WANT_DEC_FP__
+#endif
+
+#include <float.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <math.h>
+
+#define _WANT_VC 1
+#include "scaffold.c"
+
+typedef struct
+{
+  int line;
+  int round_mode;
+  _Decimal128 set;
+  double expect;
+} d_type;
+
+/* Decimal 128 to Binary Double 64.  */
+static const d_type d128to64[] = {
+ {__LINE__, FE_TONEAREST, 1e1000DL, INFINITY},
+ {__LINE__, FE_TONEAREST, -1e1000DL, -INFINITY},
+ {__LINE__, FE_TOWARDZERO, 1e1000DL, DBL_MAX},
+ {__LINE__, FE_TOWARDZERO, -1e1000DL, -DBL_MAX},
+ {__LINE__, FE_DOWNWARD, 1e1000DL, DBL_MAX},
+ {__LINE__, FE_DOWNWARD, -1e1000DL, -INFINITY},
+ {__LINE__, FE_UPWARD, 1e1000DL, INFINITY},
+ {__LINE__, FE_UPWARD, -1e1000DL, -DBL_MAX}
+};
+
+/* Decimal 128 to Binary Float 32.  */
+static const d_type d128to32[] = {
+ {__LINE__, FE_TONEAREST, 1e1000DL, INFINITY},
+ {__LINE__, FE_TONEAREST, -1e1000DL, -INFINITY},
+ {__LINE__, FE_TOWARDZERO, 1e1000DL, FLT_MAX},
+ {__LINE__, FE_TOWARDZERO, -1e1000DL, -FLT_MAX},
+ {__LINE__, FE_DOWNWARD, 1e1000DL, FLT_MAX},
+ {__LINE__, FE_DOWNWARD, -1e1000DL, -INFINITY},
+ {__LINE__, FE_UPWARD, 1e1000DL, INFINITY},
+ {__LINE__, FE_UPWARD, -1e1000DL, -FLT_MAX}
+};
+
+static const int d128to64_size = sizeof (d128to64) / sizeof (d128to64[0]);
+
+static const int d128to32_size = sizeof (d128to32) / sizeof (d128to32[0]);
+
+int
+main(void)
+{
+  int i;
+  for (i=0; i<d128to64_size; ++i)
+    {
+      double ret;
+      fesetround (d128to64[i].round_mode);
+      ret = (double) d128to64[i].set;
+      _VC_P (__FILE__, d128to64[i].line, d128to64[i].expect, ret, "%a");
+    }
+
+  for (i=0; i<d128to32_size; ++i)
+    {
+      float ret;
+      fesetround (d128to32[i].round_mode);
+      ret = (float) d128to32[i].set;
+      _VC_P (__FILE__, d128to32[i].line, d128to32[i].expect, ret, "%a");
+    }
+
+  _REPORT();
+
+  /* fail comes from scaffold.c  */
+  return fail;
+}


### PR DESCRIPTION
This commit fixes incorrect conversions between decimal and binary types that
always produce an infinity for obviously overflowing results, without taking
account of the rounding mode (task #31).

Signed-off-by: Rogerio Alves <rcardoso@linux.vnet.ibm.com>