### PR TITLE
Fix incorrect conversion on underflow.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -326,7 +326,7 @@ GLIBC_LIBS := -lc -lm
 libdfp_c_tests = test-printf test-amort test-decode \
 		 test-strtod test-numdigits test-get_digits \
 		 test-fenv test-bfp-conversions test-type-conversions test-wchar \
-		 test-getexp test-setexp test-left_justify \
+		 test-getexp test-setexp test-left_justify test-cast-to-underflow \
 		 test-fpclassify-d32 test-fpclassify-d64 test-fpclassify-d128 \
 		 test-fabs-d32 test-fabs-d64 test-fabs-d128 \
 		 test-copysign-d32 test-copysign-d64 test-copysign-d128 \

--- a/base-math/truncdddf.c
+++ b/base-math/truncdddf.c
@@ -28,6 +28,9 @@
 #define DEST 64
 #define NAME trunc
 
+#include <float.h>
+#include <fenv.h>
+
 #include "dfpacc.h"
 #include "convert.h"
 #include "convert_helpers.h"
@@ -55,7 +58,19 @@ CONVERT_WRAPPER(
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_UNDERFLOW|FE_INEXACT);
-	    return SIGNBIT(a) ? -0.0 : 0.0;
+
+	    switch (fegetround())
+	      {
+	        case FE_TONEAREST:
+	          return SIGNBIT(a) ? -__DBL_DENORM_MIN__ : __DBL_DENORM_MIN__;
+	        case FE_DOWNWARD:
+	          return SIGNBIT(a) ? -__DBL_DENORM_MIN__ : 0.0;
+	        case FE_UPWARD:
+	          return SIGNBIT(a) ? -0.0 : __DBL_DENORM_MIN__;
+	        case FE_TOWARDZERO:
+	        default:
+	          return  SIGNBIT(a) ? -0.0 : 0.0;
+	      }
 	  }
 
 	mant = a_norm;			/* 16 digits of mantissa.  */

--- a/base-math/truncddsf.c
+++ b/base-math/truncddsf.c
@@ -28,6 +28,9 @@
 #define DEST 32
 #define NAME trunc
 
+#include <float.h>
+#include <fenv.h>
+
 #include "dfpacc.h"
 #include "convert.h"
 #include "convert_helpers.h"
@@ -53,7 +56,19 @@ CONVERT_WRAPPER(
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_UNDERFLOW|FE_INEXACT);
-	    return SIGNBIT(a) ? -0.0 : 0.0;
+
+	    switch (fegetround())
+	      {
+	        case FE_TONEAREST:
+              return SIGNBIT(a) ? -__FLT_DENORM_MIN__ : __FLT_DENORM_MIN__;
+	        case FE_DOWNWARD:
+	          return SIGNBIT(a) ? -__FLT_DENORM_MIN__ : 0.0;
+	        case FE_UPWARD:
+	          return SIGNBIT(a) ? -0.0 : __FLT_DENORM_MIN__;
+	        case FE_TOWARDZERO:
+	        default:
+	          return  SIGNBIT(a) ? -0.0 : 0.0;
+	      }
 	  }
 
 	mant = a_norm;			/* 16 digits of mantissa.  */

--- a/base-math/trunctddf.c
+++ b/base-math/trunctddf.c
@@ -28,6 +28,9 @@
 #define DEST 64
 #define NAME trunc
 
+#include <float.h>
+#include <fenv.h>
+
 #include "dfpacc.h"
 #include "convert.h"
 
@@ -54,7 +57,19 @@ CONVERT_WRAPPER(
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_UNDERFLOW|FE_INEXACT);
-	    return SIGNBIT(a) ? -0.0 : 0.0;
+
+	    switch (fegetround())
+	      {
+	        case FE_TONEAREST:
+              return SIGNBIT(a) ? -__DBL_DENORM_MIN__ : __DBL_DENORM_MIN__;
+	        case FE_DOWNWARD:
+	          return SIGNBIT(a) ? -__DBL_DENORM_MIN__ : 0.0;
+	        case FE_UPWARD:
+	          return SIGNBIT(a) ? -0.0 : __DBL_DENORM_MIN__;
+	        case FE_TOWARDZERO:
+	        default:
+	          return  SIGNBIT(a) ? -0.0 : 0.0;
+	      }
 	  }
 
 	mant = a_norm;   /* Convert 17 digit mantissa to DI integer.  */

--- a/base-math/trunctdsf.c
+++ b/base-math/trunctdsf.c
@@ -28,6 +28,9 @@
 #define DEST 32
 #define NAME trunc
 
+#include <float.h>
+#include <fenv.h>
+
 #include "dfpacc.h"
 #include "convert.h"
 #include "convert_helpers.h"
@@ -52,7 +55,19 @@ CONVERT_WRAPPER(
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_UNDERFLOW|FE_INEXACT);
-	    return SIGNBIT(a) ? -0.0 : 0.0;
+
+	    switch (fegetround())
+	      {
+	        case FE_TONEAREST:
+              return SIGNBIT(a) ? -__FLT_DENORM_MIN__ : __FLT_DENORM_MIN__;
+	        case FE_DOWNWARD:
+	          return SIGNBIT(a) ? -__FLT_DENORM_MIN__ : 0.0;
+	        case FE_UPWARD:
+	          return SIGNBIT(a) ? -0.0 : __FLT_DENORM_MIN__;
+	        case FE_TOWARDZERO:
+	        default:
+	          return  SIGNBIT(a) ? -0.0 : 0.0;
+	      }
 	  }
 
 	mant = a_norm;				/* 15 digits of mantissa.  */

--- a/tests/test-cast-to-underflow.c
+++ b/tests/test-cast-to-underflow.c
@@ -1,0 +1,97 @@
+/* Test trucate cast Decimal -> Binary overflow.
+
+   Copyright (C) 2017 Free Software Foundation, Inc.
+
+   This file is part of the Decimal Floating Point C Library.
+
+   Author: Rogerio Alves <rogealve@br.ibm.com>
+
+   The Decimal Floating Point C Library is free software; you can
+   redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License version 2.1.
+
+   The Decimal Floating Point C Library is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+   the GNU Lesser General Public License version 2.1 for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License version 2.1 along with the Decimal Floating Point C Library;
+   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+   Suite 330, Boston, MA 02111-1307 USA.
+
+   Please see libdfp/COPYING.txt for more information.  */
+
+#ifndef __STDC_WANT_DEC_FP__
+#define __STDC_WANT_DEC_FP__
+#endif
+
+#include <float.h>
+#include <stdio.h>
+#include <fenv.h>
+#include <math.h>
+
+#define _WANT_VC 1
+#include "scaffold.c"
+
+typedef struct
+{
+  int line;
+  int round_mode;
+  _Decimal128 set;
+  double expect;
+} d_type;
+
+/* Decimal 128 to Binary Double 64.  */
+static const d_type d128to64[] = {
+ {__LINE__, FE_TONEAREST, 1e-1000DL, __DBL_DENORM_MIN__},
+ {__LINE__, FE_TONEAREST, -1e-1000DL, -__DBL_DENORM_MIN__},
+ {__LINE__, FE_TOWARDZERO, 1e-1000DL, 0.0},
+ {__LINE__, FE_TOWARDZERO, -1e-1000DL, -0.0},
+ {__LINE__, FE_DOWNWARD, 1e-1000DL, 0.0},
+ {__LINE__, FE_DOWNWARD, -1e-1000DL, -__DBL_DENORM_MIN__},
+ {__LINE__, FE_UPWARD, 1e-1000DL, __DBL_DENORM_MIN__},
+ {__LINE__, FE_UPWARD, -1e-1000DL, -0.0}
+};
+
+/* Decimal 128 to Binary Float 32.  */
+static const d_type d128to32[] = {
+ {__LINE__, FE_TONEAREST, 1e-1000DL, __FLT_DENORM_MIN__},
+ {__LINE__, FE_TONEAREST, -1e-1000DL, -__FLT_DENORM_MIN__},
+ {__LINE__, FE_TOWARDZERO, 1e-1000DL, 0.0},
+ {__LINE__, FE_TOWARDZERO, -1e-1000DL, -0.0},
+ {__LINE__, FE_DOWNWARD, 1e-1000DL, 0.0},
+ {__LINE__, FE_DOWNWARD, -1e-1000DL, -__FLT_DENORM_MIN__},
+ {__LINE__, FE_UPWARD, 1e-1000DL, __FLT_DENORM_MIN__},
+ {__LINE__, FE_UPWARD, -1e-1000DL, -0.0}
+};
+
+static const int d128to64_size = sizeof (d128to64) / sizeof (d128to64[0]);
+
+static const int d128to32_size = sizeof (d128to32) / sizeof (d128to32[0]);
+
+int
+main(void)
+{
+  int i;
+  for (i=0; i<d128to64_size; ++i)
+    {
+      double ret;
+      fesetround (d128to64[i].round_mode);
+      ret = (double) d128to64[i].set;
+      _VC_P (__FILE__, d128to64[i].line, d128to64[i].expect, ret, "%a");
+    }
+
+  for (i=0; i<d128to32_size; ++i)
+    {
+      float ret;
+      fesetround (d128to32[i].round_mode);
+      ret = (float) d128to32[i].set;
+      _VC_P (__FILE__, d128to32[i].line, d128to32[i].expect, ret, "%a");
+    }
+
+  _REPORT();
+
+  /* fail comes from scaffold.c  */
+  return fail;
+}


### PR DESCRIPTION
This commit fixes incorrect conversions between decimal and binary types that
always produce an +/-0.0 for obviously overflowing results, without taking
account of the rounding mode (task #32).

Signed-off-by: Rogerio Alves <rcardoso@linux.vnet.ibm.com>