### PR TITLE
Allow use of -Werror

### DIFF
--- a/configure
+++ b/configure
@@ -4385,12 +4385,11 @@ int
 main ()
 {
 
- static int foo;
  void foo_va (void *mem, va_list *ap)
  {
    return;
  }
- foo = register_printf_type (foo_va);
+ register_printf_type (foo_va);
 
   ;
   return 0;

--- a/configure.ac
+++ b/configure.ac
@@ -351,12 +351,11 @@ fi
 have_glibc_2_10_headers=yes
 AC_MSG_CHECKING([for printf-hook register_printf_type() in printf.h to verify GLIBC 2.10])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include "printf.h"]], [[
- static int foo;
  void foo_va (void *mem, va_list *ap)
  {
    return;
  }
- foo = register_printf_type (foo_va);
+ register_printf_type (foo_va);
  ]])],[AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no]); have_glibc_2_10_headers=no])
 
 if test x$have_glibc_2_10_headers != xyes; then

--- a/ieee754r/erfd32.c
+++ b/ieee754r/erfd32.c
@@ -156,7 +156,6 @@ deval (_Decimal128 x, const _Decimal128 *p, int n)
 
 static const _Decimal128
 tiny = 1e-4931DL,
-  half = 0.5DL,
   one = 1.0DL,
   two = 2.0DL,
   /* 2/sqrt(pi) - 1 */

--- a/ieee754r/lgammad32.c
+++ b/ieee754r/lgammad32.c
@@ -97,10 +97,6 @@
 #include <dfpmacro.h>
 #include <ieee754r_private.h>
 
-static const _Decimal128 PIDL = 3.1415926535897932384626433832795028841972E0DL;
-static const _Decimal128 MAXDLGM = 1.0485738685148938358098967157129705071571E4928DL;
-static const _Decimal128 one = 1.0DL;
-static const _Decimal128 zero = 0.0DL;
 static const _Decimal128 huge = 1.0e4000DL;
 
 /* log gamma(x) = ( x - 0.5 ) * log(x) - x + DLS2PI + 1/x P(1/x^2)

--- a/strtod32.c
+++ b/strtod32.c
@@ -903,10 +903,13 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 	      {
 		int inner = 0;
 		if (thousands != NULL && *startp == *thousands
-		    && ({ for (inner = 1; thousands[inner] != '\0'; ++inner)
-			if (thousands[inner] != startp[inner])
-			  break;
-			thousands[inner] == '\0'; }))
+		    && ({
+			  for (inner = 1; thousands[inner] != '\0'; ++inner)
+			    if (thousands[inner] != startp[inner])
+			      break;
+			  thousands[inner] == '\0';
+			})
+		    )
 		  startp += inner;
 		else
 		  startp += decimal_len;


### PR DESCRIPTION
Some warnings currently prevent the use of `-Werror` in CFLAGS in libdfp.  This patch set cleans up the warnings, thus allowing the following command to complete successfully:

```
CFLAGS="-Wall -Werror -O2" ./configure
make && make check
```

People testing libdfp in continuous integration would be able to use it and get cleaner logs.