### PR TITLE
Cleanup files for GCC 8

### DIFF
--- a/fmt_d32.c
+++ b/fmt_d32.c
@@ -176,7 +176,7 @@ char * INTERNAL_FUNCTION_NAME ( const struct printf_info *info,
   else /* Set the null terminator before copying the string.  */
     str[dtoslen] = 0x0;
 
-  strncpy(padded, dtos, dtoslen);
+  memcpy(padded, dtos, dtoslen);
   memset(dtos, 0x0, MAX_DECIMAL128_STRING);
 
   return str;

--- a/sysdeps/dpd/dpd-private.h
+++ b/sysdeps/dpd/dpd-private.h
@@ -304,8 +304,8 @@ struct ieee754r_c_field
 extern const struct ieee754r_c_field c_decoder[32];
 extern const unsigned char lm2lmd_to_c[10][4];
 extern const char	dpd_to_char[1024][4];
-extern const const short int	dpd_to_bcd[1024];
-extern const const short int	dpd_to_bin[1024];
+extern const short int	dpd_to_bcd[1024];
+extern const short int	dpd_to_bin[1024];
 extern const short int	bcd_to_dpd[2464];
 
 static inline unsigned int


### PR DESCRIPTION
With this patch, we can use -Wall -Werror on GCC 8.