### PR TITLE
Adapt the code for glibc 2.28

### DIFF
--- a/printf_dfp.c
+++ b/printf_dfp.c
@@ -117,9 +117,6 @@ padn (FILE *fp, int pad, int count)
 
 #define PAD(f, c, n) (wide ? wpadn (f, c, n) : padn (f, c, n))
 
-#define size_t     _IO_size_t
-#define FILE	     _IO_FILE
-
 /* Macros for doing the actual output.  */
 
 #define outchar(ch)							      \


### PR DESCRIPTION
Replace the following references:
 - _IO_size_t with size_t;
 - _IO_FILE with FILE.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>