### PR TITLE
Add support for POWER9 and others

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -383,7 +383,8 @@ $(addsuffix .os, $(libdfp_cxx_tests)): $(top_srcdir)/dfp/decimal/decimal $(top_s
 # Add the ULP file generation explicity rule
 $(addprefix $(objpfx), $(libdfp_tests)): $(top_builddir)/libdfp-test-ulps.h
 
-ulps-file = $(shell find $(sysdep_dirs:%=$(top_srcdir)/%/libdfp-test-ulps))
+ulps-file = $(shell find $(sysdep_dirs:%=$(top_srcdir)/%/) \
+			 -name libdfp-test-ulps | head -1)
 $(top_builddir)/libdfp-test-ulps.h: $(ulps-file)
 	$(top_srcdir)/tests/gen-libdfp-ulps.py $< -o $@
 

--- a/configure
+++ b/configure
@@ -4147,22 +4147,7 @@ if test "${with_cpu+set}" = set; then :
   no)
     with_dfp=no
     ;;
-  power8)
-    submachine="$withval"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: configuring for the $submachine processor" >&5
-$as_echo "$as_me: configuring for the $submachine processor" >&6;}
-    with_dfp=yes ;;
-  power7)
-    submachine="$withval"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: configuring for the $submachine processor" >&5
-$as_echo "$as_me: configuring for the $submachine processor" >&6;}
-    with_dfp=yes ;;
-  power6)
-    submachine="$withval"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: configuring for the $submachine processor" >&5
-$as_echo "$as_me: configuring for the $submachine processor" >&6;}
-    with_dfp=yes ;;
-  power6x)
+  power[6-9]|power6x)
     submachine="$withval"
     { $as_echo "$as_me:${as_lineno-$LINENO}: configuring for the $submachine processor" >&5
 $as_echo "$as_me: configuring for the $submachine processor" >&6;}

--- a/configure.ac
+++ b/configure.ac
@@ -194,19 +194,7 @@ AC_ARG_WITH([cpu],
   no)
     with_dfp=no
     ;;
-  power8)
-    submachine="$withval"
-    AC_MSG_NOTICE(configuring for the $submachine processor)
-    with_dfp=yes ;;
-  power7)
-    submachine="$withval"
-    AC_MSG_NOTICE(configuring for the $submachine processor)
-    with_dfp=yes ;;
-  power6)
-    submachine="$withval"
-    AC_MSG_NOTICE(configuring for the $submachine processor)
-    with_dfp=yes ;;
-  power6x)
+  power[[6-9]]|power6x)
     submachine="$withval"
     AC_MSG_NOTICE(configuring for the $submachine processor)
     with_dfp=yes ;;

--- a/sysdeps/powerpc/powerpc32/power9/Implies
+++ b/sysdeps/powerpc/powerpc32/power9/Implies
@@ -1,0 +1,1 @@
+sysdeps/powerpc/powerpc32/power8

--- a/sysdeps/powerpc/powerpc32/power9/fpu/Implies
+++ b/sysdeps/powerpc/powerpc32/power9/fpu/Implies
@@ -1,0 +1,1 @@
+sysdeps/powerpc/powerpc32/power8/fpu

--- a/sysdeps/powerpc/powerpc64/power9/Implies
+++ b/sysdeps/powerpc/powerpc64/power9/Implies
@@ -1,0 +1,1 @@
+sysdeps/powerpc/powerpc64/power8

--- a/sysdeps/powerpc/powerpc64/power9/fpu/Implies
+++ b/sysdeps/powerpc/powerpc64/power9/fpu/Implies
@@ -1,0 +1,1 @@
+sysdeps/powerpc/powerpc64/power8/fpu

--- a/tests/scaffold.c
+++ b/tests/scaffold.c
@@ -158,10 +158,18 @@ static char buf[1024];
 
 /* _PC == Printf_dfp Compare with Position  */
 #define _PC_P(f,l,x,y,args...) do { \
+  size_t __tmp; \
   memset(buf,'\0',CHAR_MAX); \
   /* Invokes printf dfp.  */  \
-  sprintf(buf, y, ##args); \
+  __tmp = sprintf(buf, y, ##args); \
   _SC_P(f,l,x,buf); \
+  if (__tmp != strlen(x)) { \
+    fprintf(stderr, "%-3d Error: fprintf didn't return the correct size." \
+	    "  Expected: \"%zd\"\n           " \
+	    "  Result:   \"%zd\"\n    in: %s:%d.\n\n", \
+	    testnum,strlen(x),__tmp,f,l); \
+    ++fail; \
+  } \
 } while (0)
 
 /* _PC == Printf_dfp Compare


### PR DESCRIPTION
1. Improve current tests to validate the return code from *printf() upon successful calls.
2. Add support for POWER9.
3. Remove the ugly messages from find that appear when running make.