### PR TITLE
Fix overflow test failures for flt32 conversion.

### DIFF
--- a/base-math/trunctdsf.c
+++ b/base-math/trunctdsf.c
@@ -45,7 +45,7 @@ CONVERT_WRAPPER(
 	a_norm = getmantandexpd128 (a, &exp, 15, 1e15DL);
 	/* Handle obvious overflow and underflow to avoid going beyond the
 	   bounds of the exponent table.  */
-	if (exp > 39)		/* Obvious overflow.  */
+	if (exp > FLT_MAX_10_EXP)		/* Obvious overflow.  */
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_OVERFLOW|FE_INEXACT);


### PR DESCRIPTION
This commit fixes the two failures on cast-to-overflow test which
converts a Decimal32 to a float (binary 32). The range should be 38
or FLT_MAX_10_EXP not 39.

Signed-off-by: Rogerio Alves <rcardoso@linux.ibm.com>