### PR TITLE
Fix expoenent range check on Decimal64 to Float conversion

### DIFF
--- a/base-math/truncddsf.c
+++ b/base-math/truncddsf.c
@@ -46,7 +46,7 @@ CONVERT_WRAPPER(
 
 	/* Check for values that would overflow the exponent table, which
 	   would be obvious overflow and underflow.  */
-	if (exp > 39)		/* Obvious overflow.  */
+	if (exp > FLT_MAX_10_EXP)		/* Obvious overflow.  */
 	  {
 	    if (DFP_EXCEPTIONS_ENABLED)
 	      DFP_HANDLE_EXCEPTIONS (FE_OVERFLOW|FE_INEXACT);


### PR DESCRIPTION
The range should be 38 or FLT_MAX_10_EXP not 39 to check if the exponent
is out of range on Decimal64 to float (binary 32) conversion.

Signed-off-by: Rogerio Alves <rcardoso@linux.ibm.com>