### PR TITLE
Install COPYING.txt in inst_docdir.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -533,6 +533,7 @@ install-doc: $(top_srcdir)/ChangeLog.md
 	$(INSTALL) -t $(inst_docdir)dfp/ $(top_srcdir)/README.user
 	mv $(inst_docdir)dfp/README.user $(inst_docdir)dfp/README
 	$(INSTALL) -t $(inst_docdir)dfp/ $(top_srcdir)/ChangeLog.md
+	$(INSTALL) -t $(inst_docdir)dfp/ $(top_srcdir)/COPYING.txt
 .PHONY: install-doc
 
 $(top_srcdir)/ChangeLog.md:


### PR DESCRIPTION
Also install COPYING.txt to /usr/share/doc/dfp/COPYING.txt.
Then this file can be specified as %license in a spec file for an rpm package.

Signed-off-by: Stefan Liebler <stli@linux.ibm.com>