### PR TITLE
Small fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -489,7 +489,7 @@ tests: $(libdfp_tests:%=%.out)
 	@echo Details of failed tests:
 	@awk -v builddir=$(top_builddir) \
 	'{ if ($$1 != "PASS:") printf "%s/%s.out ", builddir, $$2; }' \
-	tests.sum | xargs -n 1 cat
+	tests.sum | xargs -n 1 -t cat
 	$(call summarize-tests,tests.sum)
 
 # The .out files are predicated in another rule on the actual test executables, so

--- a/Makefile.in
+++ b/Makefile.in
@@ -15,19 +15,19 @@ docdir = @docdir@
 ifndef libdir
 libdir = $(exec_prefix)/lib
 endif
-inst_libdir = $(install_root)$(libdir)
+inst_libdir = $(DESTDIR)$(libdir)
 
 # Where to install the header files.
 ifndef includedir
 includedir = $(prefix)/include
 endif
-inst_includedir = $(install_root)$(includedir)
+inst_includedir = $(DESTDIR)$(includedir)
 
 # Where to install the README document
 ifndef docdir
 docdir = $(prefix)/share/doc/
 endif
-inst_docdir = $(install_root)$(docdir)
+inst_docdir = $(DESTDIR)$(docdir)
 
 dfp_name = @PACKAGE_NAME@
 dfp_version = @PACKAGE_VERSION@

--- a/README.developer
+++ b/README.developer
@@ -632,15 +632,15 @@ make check
 		later.  The path to the build was passed to configure using
 		the --with-glibc-build switch.
 
-make install [install_root=<path>]
+make install [DESTDIR=<path>]
 
-	[install_root] (Optional) : Install to <path>/$prefix.  This is used
+	[DESTDIR] (Optional) : Install to <path>/$prefix.  This is used
 	by libdfp developers and distro builders so that they can build libdfp
 	and install it to an alternate location in preparation for packaging.
 
-make install-headers [install_root=<path>]
+make install-headers [DESTDIR=<path>]
 
-	[install_root] (Optional) : Install libdfp headers into
+	[DESTDIR] (Optional) : Install libdfp headers into
 	<path>/$prefix/include/dfp.  This is used by application or library
 	developers whose projects depend on libdfp who don't want to install
 	libdfp proper or may not have permission to do so.


### PR DESCRIPTION
Add 2 patches with simple changes:

1. Re-add information removed from PR #87 .
2. Make libdfp friendlier to downstream by using DESTDIR instead of install_root.