### PR TITLE
S390: Add support for z15/arch13 s390 cpu.

### DIFF
--- a/configure
+++ b/configure
@@ -4152,7 +4152,7 @@ if test "${with_cpu+set}" = set; then :
     { $as_echo "$as_me:${as_lineno-$LINENO}: configuring for the $submachine processor" >&5
 $as_echo "$as_me: configuring for the $submachine processor" >&6;}
     with_dfp=yes ;;
-  z9-ec|z10|z196|zEC12|z13|arch12|z14)
+  z9-ec|z10|z196|zEC12|z13|arch12|z14|arch13|z15)
     submachine="$withval"
     # Warning, -mzarch won't get passed to libecnumber/configure
     mzarch="-mzarch"

--- a/configure.ac
+++ b/configure.ac
@@ -198,7 +198,7 @@ AC_ARG_WITH([cpu],
     submachine="$withval"
     AC_MSG_NOTICE(configuring for the $submachine processor)
     with_dfp=yes ;;
-  z9-ec|z10|z196|zEC12|z13|arch12|z14)
+  z9-ec|z10|z196|zEC12|z13|arch12|z14|arch13|z15)
     submachine="$withval"
     # Warning, -mzarch won't get passed to libecnumber/configure
     mzarch="-mzarch"


### PR DESCRIPTION
This patch adds support for configure flag --with-cpu for the new CPU z15.

Note: z15==arch13, but there exists gcc/binutils versions which do support -march=arch13 but not -march=z15.

Signed-off-by: Stefan Liebler <stli@linux.ibm.com>