### PR TITLE
Fix TabError in tests/gen-libdfp-tests.py. #121

### DIFF
--- a/tests/gen-libdfp-tests.py
+++ b/tests/gen-libdfp-tests.py
@@ -278,9 +278,9 @@ def parse_file (filename):
 
     for earg in extra_args:
       if earg in cppcheckdict.keys():
-	op.cppchecks.append(cppcheckdict[earg])
+        op.cppchecks.append(cppcheckdict[earg])
       else:
-	op.extraflags.append(earg)
+        op.extraflags.append(earg)
 
     # Finally, if we ignore the results, coerce to a value
     # which won't make the compiler generate warnings:


### PR DESCRIPTION
Generating the tests with python3 fails due to the following error:
  File "tests/gen-libdfp-tests.py", line 281
    op.cppchecks.append(cppcheckdict[earg])
                                          ^
TabError: inconsistent use of tabs and spaces in indentation

This patch just exchanges the TAB with spaces.

Signed-off-by: Stefan Liebler <stli@linux.ibm.com>