### PR TITLE
Add pkg-config file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -414,6 +414,7 @@ endif
 	$(INSTALL) -t $(inst_libdir) $(top_builddir)/$(SHARED_REALNAME_LIB)
 	ln -f -s $(SHARED_REALNAME_LIB) $(inst_libdir)/$(SHARED_LINKERNAME_LIB)
 	ln -f -s $(SHARED_REALNAME_LIB) $(inst_libdir)/$(SHARED_SONAME_LIB)
+	$(INSTALL) -t $(inst_libdir)/pkgconfig $(top_srcdir)/libdfp.pc
 .PHONY: install
 
 install-headers:

--- a/configure
+++ b/configure
@@ -6303,7 +6303,7 @@ fi
 # This tells autoconf to generate Makefile from the Makefile.in.  This is the
 # top level Makefile for the project.  This Makefile will then recurse into
 # the fragment Makefiles in the sysdeps directories.
-ac_config_files="$ac_config_files Makefile"
+ac_config_files="$ac_config_files Makefile libdfp.pc"
 
 
 cat >confcache <<\_ACEOF
@@ -7000,6 +7000,7 @@ do
   case $ac_config_target in
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "libdfp.pc") CONFIG_FILES="$CONFIG_FILES libdfp.pc" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -524,6 +524,6 @@ AS_IF([test $libc_cv_compiler_ok != yes],
 # This tells autoconf to generate Makefile from the Makefile.in.  This is the
 # top level Makefile for the project.  This Makefile will then recurse into
 # the fragment Makefiles in the sysdeps directories.
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile libdfp.pc])
 
 AC_OUTPUT

--- a/libdfp.pc.in
+++ b/libdfp.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: Decimal Floating Point C Library
+URL: https://github.com/libdfp/libdfp
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}/dfp -D__STDC_WANT_DEC_FP__
+Libs: -L${libdir} -ldfp


### PR DESCRIPTION
As suggested in #123, this file will ease the usage of libdfp by setting a proper include directory for C headers and the expected `__STDC_WANT_DEC_FP__` definition.