### PR TITLE
Fix pkg-config.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -414,7 +414,7 @@ endif
 	$(INSTALL) -t $(inst_libdir) $(top_builddir)/$(SHARED_REALNAME_LIB)
 	ln -f -s $(SHARED_REALNAME_LIB) $(inst_libdir)/$(SHARED_LINKERNAME_LIB)
 	ln -f -s $(SHARED_REALNAME_LIB) $(inst_libdir)/$(SHARED_SONAME_LIB)
-	$(INSTALL) -t $(inst_libdir)/pkgconfig $(top_srcdir)/libdfp.pc
+	$(INSTALL) -D -t $(inst_libdir)/pkgconfig $(top_builddir)/libdfp.pc
 .PHONY: install
 
 install-headers:


### PR DESCRIPTION
If build in a separate build directory, the configure does not create
the libdfp.pc file in top_srcdir, but in top_builddir.

Furthermore, the install command failed as there was no pkgconfig
directory in inst_libdir. Added the -D flag which creates this directory.