### PR TITLE
S390: Mark internal quantized function as hidden.

### DIFF
--- a/sysdeps/s390/dfpu/quantized32.c
+++ b/sysdeps/s390/dfpu/quantized32.c
@@ -23,6 +23,7 @@
 #endif
 
 #include <math.h>
+#include <ieee754r_private.h>
 
 #define FUNCTION_NAME quantize
 #include <dfpmacro.h>
@@ -65,4 +66,5 @@ INTERNAL_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
 
   return (DEC_TYPE) result;
 }
+hidden_def (INTERNAL_FUNCTION_NAME)
 weak_alias (INTERNAL_FUNCTION_NAME, EXTERNAL_FUNCTION_NAME)


### PR DESCRIPTION
Starting with the recent commit 7a02479235285772ad7a24a6e4828f92b6d068e1
the internal quantized functions are makred as hidden.

This just do the same for s390x there is an own implementation.