### PR TITLE
Explicitly require python, and favor python3

### DIFF
--- a/configure
+++ b/configure
@@ -637,6 +637,8 @@ machine
 base_machine
 with_fp
 ASFLAGS
+PYTHON
+PYTHON_PROG
 LDD
 GDB
 READELF
@@ -5159,6 +5161,57 @@ $as_echo "no" >&6; }
 fi
 
 
+
+
+# Check for python3 if available, or else python.
+# Borrowed from glibc.
+for ac_prog in python3 python
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_PYTHON_PROG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$PYTHON_PROG"; then
+  ac_cv_prog_PYTHON_PROG="$PYTHON_PROG" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_PYTHON_PROG="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+PYTHON_PROG=$ac_cv_prog_PYTHON_PROG
+if test -n "$PYTHON_PROG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_PROG" >&5
+$as_echo "$PYTHON_PROG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$PYTHON_PROG" && break
+done
+test -n "$PYTHON_PROG" || PYTHON_PROG="no-python"
+
+if test $PYTHON_PROG == no-python; then
+  as_fn_error $? "python is required" "$LINENO" 5
+fi
+PYTHON="$PYTHON_PROG -B"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,15 @@ AC_PATH_PROG([LDD], [ldd])
 AC_ARG_VAR(LDD,The path to the ldd used by the debug scripts.
 Defaults to that found in $$PATH)
 
+# Check for python3 if available, or else python.
+# Borrowed from glibc.
+AC_CHECK_PROGS([PYTHON_PROG],python3 python, no-python)
+if test $PYTHON_PROG == no-python; then
+  AC_MSG_ERROR([python is required])
+fi
+PYTHON="$PYTHON_PROG -B"
+
+AC_SUBST(PYTHON)
 AC_SUBST(CFLAGS)
 AC_SUBST(CXXFLAGS)
 AC_SUBST(CPPFLAGS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -58,17 +58,17 @@ libdfp_c_tests += $(libdfp_c_autotests)
 test-%-d%: $(addsuffix .os,$@)
 	$(CC) $(CFLAGS) $(sysdeps-CFLAGS) $(GLIBC_LIBS) -L$(top_builddir)/ -ldfp $(top_builddir)/$^ -o $@
 test-%-d32.c: %.input
-	$(top_srcdir)/tests/gen-libdfp-tests.py -t decimal32 $^ > $(top_builddir)/$@
+	$(PYTHON) $(top_srcdir)/tests/gen-libdfp-tests.py -t decimal32 $^ > $(top_builddir)/$@
 test-%-d64.c: %.input
-	$(top_srcdir)/tests/gen-libdfp-tests.py -t decimal64 $^ > $(top_builddir)/$@
+	$(PYTHON) $(top_srcdir)/tests/gen-libdfp-tests.py -t decimal64 $^ > $(top_builddir)/$@
 test-%-d128.c: %.input
-	$(top_srcdir)/tests/gen-libdfp-tests.py -t decimal128 $^ > $(top_builddir)/$@
+	$(PYTHON) $(top_srcdir)/tests/gen-libdfp-tests.py -t decimal128 $^ > $(top_builddir)/$@
 
 ulps-file = $(shell find $(sysdep_dirs:%=$(top_srcdir)/%/) \
 			 -name libdfp-test-ulps | head -1)
 
 libdfp-test-ulps.h: $(ulps-file)
-	$(top_srcdir)/tests/gen-libdfp-ulps.py $< -o $@
+	$(PYTHON) $(top_srcdir)/tests/gen-libdfp-ulps.py $< -o $@
 
 # Add the ULP file generation explicity rule
 $(addprefix $(objpfx), $(libdfp_c_tests)): $(top_builddir)/libdfp-test-ulps.h


### PR DESCRIPTION
Similarly, update the test scripts to use the detected python
instead of rolling the dice from the environment.  All test
scripts should support it.

This was partially cribbed from glibc, but we are less picky
about version.

This should fix #83.