### PR TITLE
libdecnumber: fix srcdir==builddir builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -166,7 +166,7 @@ BACKEND_CFLAGS=$(cflags-cpu) $(picflag)
 
 libdecnumber/libdecnumber.a:
 	@echo "+Building DFP backend $@"
-	DEFS="-D__STDC_DEC_FP__=200704L $(CFLAGS-sysdeps) $(BACKEND_CFLAGS)" $(MAKE) -C libdecnumber
+	DEFS="-D__STDC_DEC_FP__=200704L $(CFLAGS-sysdeps) $(BACKEND_CFLAGS)" $(MAKE) -C libdecnumber -f Makefile.libdecnumber
 
 libdfp: @enable_static@ @enable_shared@
 

--- a/libdecnumber/Makefile.in
+++ b/libdecnumber/Makefile.in
@@ -56,7 +56,7 @@ ADDITIONAL_OBJS = @ADDITIONAL_OBJS@
 
 enable_decimal_float= @enable_decimal_float@
 
-INCLUDES = -I$(srcdir) -I.
+INCLUDES = -I$(srcdir) -I. -I$(top_builddir)/libdecnumberconfig
 
 ALL_CFLAGS = $(CFLAGS) $(WARN_CFLAGS) $(INCLUDES) $(CPPFLAGS) $(PICFLAG)
 

--- a/libdecnumber/configure
+++ b/libdecnumber/configure
@@ -4950,9 +4950,9 @@ fi
 
 # Output.
 
-ac_config_headers="$ac_config_headers config.h:config.in"
+ac_config_headers="$ac_config_headers libdecnumberconfig/config.h:config.in"
 
-ac_config_files="$ac_config_files Makefile"
+ac_config_files="$ac_config_files Makefile.libdecnumber:Makefile.in"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5671,8 +5671,8 @@ for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
     "gstdint.h") CONFIG_COMMANDS="$CONFIG_COMMANDS gstdint.h" ;;
-    "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h:config.in" ;;
-    "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "libdecnumberconfig/config.h") CONFIG_HEADERS="$CONFIG_HEADERS libdecnumberconfig/config.h:config.in" ;;
+    "Makefile.libdecnumber") CONFIG_FILES="$CONFIG_FILES Makefile.libdecnumber:Makefile.in" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -6551,7 +6551,7 @@ else
 fi
 
  ;;
-    "config.h":H) echo timestamp > stamp-h1 ;;
+    "libdecnumberconfig/config.h":H) echo timestamp > stamp-h1 ;;
 
   esac
 done # for ac_tag

--- a/libdecnumber/configure.ac
+++ b/libdecnumber/configure.ac
@@ -104,6 +104,6 @@ AC_SUBST(PICFLAG)
 
 # Output.
 
-AC_CONFIG_HEADERS(config.h:config.in, [echo timestamp > stamp-h1])
-AC_CONFIG_FILES(Makefile)
+AC_CONFIG_HEADERS(libdecnumberconfig/config.h:config.in, [echo timestamp > stamp-h1])
+AC_CONFIG_FILES(Makefile.libdecnumber:Makefile.in)
 AC_OUTPUT


### PR DESCRIPTION
This is probably bad practice today, but IBM's internal builders do
this.  The libdfp makefile is overwritten by decnumbers during
configure.  Rename the generated makefile.

Likewise, move the generated config.h to a subdir of the builddir
to ensure it doesn't pollute the normal libdfp include paths.

Signed-off-by: Paul E. Murphy <murphyp@linux.vnet.ibm.com>