### PR TITLE
Use python3 when running bare scripts

### DIFF
--- a/tests/gen-libdfp-tests.py
+++ b/tests/gen-libdfp-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/tests/gen-libdfp-ulps.py
+++ b/tests/gen-libdfp-ulps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os


### PR DESCRIPTION
The Makefile will explicitly invoke the detected python interpreter,
however these scripts should use python3 if run directly by a
developer.