### PR TITLE
Detect srcdir with a file not removed in the release tarball 

### DIFF
--- a/configure
+++ b/configure
@@ -585,7 +585,7 @@ PACKAGE_STRING='libdfp 1.0.14'
 PACKAGE_BUGREPORT='https://github.com/libdfp/libdfp/issues'
 PACKAGE_URL=''
 
-ac_unique_file="generate-changelog.sh"
+ac_unique_file="libdfp.pc.in"
 # Factoring default headers for most tests.
 ac_includes_default="\
 #include <stdio.h>

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([libdfp],[1.0.14],[https://github.com/libdfp/libdfp/issues])
-AC_CONFIG_SRCDIR([generate-changelog.sh])
+AC_CONFIG_SRCDIR([libdfp.pc.in])
 
 # This is used for libdecnumber.
 AC_C_BIGENDIAN


### PR DESCRIPTION
generate-changelog.sh is deleted when preparing the
release tarball.  Choose a file which always exists
to prevent breaking release tarballs.

Signed-off-by: Paul E. Murphy <murphyp@linux.vnet.ibm.com>