### PR TITLE
Cleanup clean targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.a
 *.cache
+*.d
 *.jmprel
 *.log
 *.map

--- a/Makefile.in
+++ b/Makefile.in
@@ -412,8 +412,8 @@ clean:
 	rm -f $(libdfp_tests)
 	rm -f libdfp-test-ulps.h
 	rm -f *.ulp
-	rm -f $(top_builddir)/$(dfp_backend)/*.o
-	rm -f $(top_builddir)/$(dfp_backend)/*.a
+	rm -f $(top_builddir)/libdecnumber/*.o
+	rm -f $(top_builddir)/libdecnumber/*.a
 
 .PHONY: clean
 
@@ -423,12 +423,12 @@ distclean:
 	rm -f $(top_builddir)/config.log
 	rm -f $(top_builddir)/config.status
 	rm -f $(top_builddir)/Makefile
-	rm -f $(top_builddir)/$(dfp_backend)/config.h
-	rm -f $(top_builddir)/$(dfp_backend)/config.log
-	rm -f $(top_builddir)/$(dfp_backend)/config.status
-	rm -f $(top_builddir)/$(dfp_backend)/gstdint.h
-	rm -f $(top_builddir)/$(dfp_backend)/Makefile
-	rm -f $(top_builddir)/$(dfp_backend)/stamp-h1
+	rm -f $(top_builddir)/libdecnumber/config.h
+	rm -f $(top_builddir)/libdecnumber/config.log
+	rm -f $(top_builddir)/libdecnumber/config.status
+	rm -f $(top_builddir)/libdecnumber/gstdint.h
+	rm -f $(top_builddir)/libdecnumber/Makefile
+	rm -f $(top_builddir)/libdecnumber/stamp-h1
 
 .PHONY: distclean
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -397,6 +397,7 @@ cross-check:  $(filter-out $(cross-tests),$(libdfp_tests)) $(cross-tests:%=%.out
 clean:
 	rm -f *.o
 	rm -f *.os
+	rm -f *.d
 	rm -f $(STATIC_LIB)
 	rm -f $(SHARED_LINKERNAME_LIB)
 	rm -f $(SHARED_SONAME_LIB)

--- a/Makefile.in
+++ b/Makefile.in
@@ -428,8 +428,10 @@ distclean:
 	rm -f $(top_builddir)/libdecnumber/config.log
 	rm -f $(top_builddir)/libdecnumber/config.status
 	rm -f $(top_builddir)/libdecnumber/gstdint.h
-	rm -f $(top_builddir)/libdecnumber/Makefile
+	rm -f $(top_builddir)/libdecnumber/Makefile.libdecnumber
 	rm -f $(top_builddir)/libdecnumber/stamp-h1
+	rm -f $(top_builddir)/libdecnumber.pc
+	rm -f $(top_builddir)/libdfp.pc
 
 .PHONY: distclean
 


### PR DESCRIPTION
1.0.15 saw a historical amount of churn.  Admittedly, the clean targets could have used more verification.