### PR TITLE
powerpc: use __builtin_fabsdN for fabsdN

### DIFF
--- a/sysdeps/powerpc/dfpu/fabsd128.c
+++ b/sysdeps/powerpc/dfpu/fabsd128.c
@@ -24,13 +24,7 @@
 _Decimal128
 __fabsd128 (_Decimal128 x)
 {
-  /* Half part os decimal128 constainst the sign bit at same position as
-     binary64, so the instruction works for both formats.  */
-  _Decimal128 ret;
-  asm ("fabs  %0, %1\n"
-       : "=f"(ret)
-       : "f"(x));
-  return ret;
+  return __builtin_fabsd128 (x);
 }
 hidden_def (__fabsd128)
 weak_alias (__fabsd128, fabsd128)

--- a/sysdeps/powerpc/dfpu/fabsd32.c
+++ b/sysdeps/powerpc/dfpu/fabsd32.c
@@ -24,14 +24,7 @@
 _Decimal32
 __fabsd32 (_Decimal32 x)
 {
-  /* Both binary32 and decimal32 have the sign bit at same position,
-     so the instruction works for both format.  */
-  _Decimal64 tmp;
-  asm ("dctdp %0, %1\n"  /* DFP Convert To DFP Long  */
-       "fabs  %0, %0\n"
-       : "=&f"(tmp)
-       : "f" (x));
-  return (_Decimal32)tmp;
+  return __builtin_fabsd32 (x);
 }
 hidden_def (__fabsd32)
 weak_alias (__fabsd32, fabsd32)

--- a/sysdeps/powerpc/dfpu/fabsd64.c
+++ b/sysdeps/powerpc/dfpu/fabsd64.c
@@ -24,11 +24,7 @@
 _Decimal64
 __fabsd64 (_Decimal64 x)
 {
-  /* Both binary64 and decimal64 have the sign bit at same position,
-     so the instruction works for both format.  */
-  asm ("fabs  %0, %0\n"
-       : "=&f"(x));
-  return x;
+  return __builtin_fabsd64 (x);
 }
 hidden_def (__fabsd64)
 weak_alias (__fabsd64, fabsd64)


### PR DESCRIPTION
The inline asm for fabsd128 works only by strict assumption that it
is not inlined and the src and dst registers selected are identical.
When lto is used it will fail to move the lower half of the
decimal128 value causing strange failures if the value is not
computed in place.

Instead use the builtin, it's been available for quite some time
and can generate the extra move as needed.  Similarly, use the
builtins for other types as the generated code is equivalent.

This fixes the non-trivial failures discovered when turning
on lto from Issue #150.