### PR TITLE
Run tests on gcc-9 and gcc-10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,31 +3,105 @@ language: c
 
 matrix:
   include:
-    - name: "linux-amd64-gcc"
+    - name: "linux-amd64-gcc-9"
       os: linux
       arch: amd64
-      compiler: gcc
-      env: CFLAGS="-O2"
-    - name: "linux-ppc64le-gcc"
+      compiler: gcc-9
+      env:
+        - CXX="g++-9"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-9 g++-9"
+    - name: "linux-ppc64le-gcc-9"
       os: linux
       arch: ppc64le
-      compiler: gcc
-      env: CFLAGS="-O2"
-    - name: "linux-ppc64le-gcc-sw"
+      compiler: gcc-9
+      env:
+        - CXX="g++-9"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-9 g++-9"
+    - name: "linux-ppc64le-gcc-9-sw"
       os: linux
       arch: ppc64le
-      compiler: gcc
-      env: CONFIGURE_OPTS="--with-cpu=no" CFLAGS="-O2"
-    - name: "linux-s390x-gcc"
+      compiler: gcc-9
+      env:
+        - CONFIGURE_OPTS="--with-cpu=no"
+        - CXX="g++-9"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-9 g++-9"
+    - name: "linux-s390x-gcc-9"
       os: linux
       arch: s390x
-      compiler: gcc
-      env: CFLAGS="-O2"
-    - name: "linux-s390x-gcc-sw"
+      compiler: gcc-9
+      env:
+        - CXX="g++-9"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-9 g++-9"
+    - name: "linux-s390x-gcc-9-sw"
       os: linux
       arch: s390x
-      compiler: gcc
-      env: CONFIGURE_OPTS="--with-cpu=no" CFLAGS="-O2"
+      compiler: gcc-9
+      env:
+        - CONFIGURE_OPTS="--with-cpu=no"
+        - CXX="g++-9"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-9 g++-9"
+    - name: "linux-amd64-gcc-10"
+      os: linux
+      arch: amd64
+      compiler: gcc-10
+      env:
+        - CXX="g++-10"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-10 g++-10"
+    - name: "linux-ppc64le-gcc-10"
+      os: linux
+      arch: ppc64le
+      compiler: gcc-10
+      env:
+        - CXX="g++-10"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-10 g++-10"
+    - name: "linux-ppc64le-gcc-10-sw"
+      os: linux
+      arch: ppc64le
+      compiler: gcc-10
+      env:
+        - CONFIGURE_OPTS="--with-cpu=no"
+        - CXX="g++-10"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-10 g++-10"
+    - name: "linux-s390x-gcc-10"
+      os: linux
+      arch: s390x
+      compiler: gcc-10
+      env:
+        - CXX="g++-10"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-10 g++-10"
+    - name: "linux-s390x-gcc-10-sw"
+      os: linux
+      arch: s390x
+      compiler: gcc-10
+      env:
+        - CONFIGURE_OPTS="--with-cpu=no"
+        - CXX="g++-10"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-10 g++-10"
+
+before_install:
+  - sudo add-apt-repository universe
+  - sudo apt-get update
+  - sudo apt-get -y install ${PKG_CC}
 
 script:
   - mkdir $(pwd)/install


### PR DESCRIPTION
We've just seen an issue happening on gcc-11.
This is a good change to start testing on different GCC versions.
Unfortunately, gcc-11 is not yet available on Ubuntu [1].

[1] https://launchpad.net/ubuntu/+source/gcc-11

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>