### PR TITLE
Start testing with GCC 11 and a small pkgconfig fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,57 @@ matrix:
         - CFLAGS="-O2"
         - CXXFLAGS="-O2"
         - PKG_CC="gcc-10 g++-10"
+    - name: "linux-amd64-gcc-11"
+      os: linux
+      arch: amd64
+      compiler: gcc-11
+      env:
+        - CXX="g++-11"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-11 g++-11"
+    - name: "linux-ppc64le-gcc-11"
+      os: linux
+      arch: ppc64le
+      compiler: gcc-11
+      env:
+        - CXX="g++-11"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-11 g++-11"
+    - name: "linux-ppc64le-gcc-11-sw"
+      os: linux
+      arch: ppc64le
+      compiler: gcc-11
+      env:
+        - CONFIGURE_OPTS="--with-cpu=no"
+        - CXX="g++-11"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-11 g++-11"
+    - name: "linux-s390x-gcc-11"
+      os: linux
+      arch: s390x
+      compiler: gcc-11
+      env:
+        - CXX="g++-11"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-11 g++-11"
+    - name: "linux-s390x-gcc-11-sw"
+      os: linux
+      arch: s390x
+      compiler: gcc-11
+      env:
+        - CONFIGURE_OPTS="--with-cpu=no"
+        - CXX="g++-11"
+        - CFLAGS="-O2"
+        - CXXFLAGS="-O2"
+        - PKG_CC="gcc-11 g++-11"
 
 before_install:
   - sudo add-apt-repository universe
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update
   - sudo apt-get -y install ${PKG_CC}
 


### PR DESCRIPTION
1. Start running the tests on GCC 11.
2. Guarantee the pkgconfig directory is created before we try to install files in it.