### PR TITLE
Update libbid to gcc commit 57f2ce6a878

### DIFF
--- a/libbid/ChangeLog
+++ b/libbid/ChangeLog
@@ -1,3 +1,51 @@
+2022-05-20  Christophe Lyon  <christophe.lyon@arm.com>
+
+	* bid_binarydecimal.c (CLZ32_MASK16): Delete.
+	(CLZ32_MASK8): Delete.
+	(CLZ32_MASK4): Delete.
+	(CLZ32_MASK2): Delete.
+	(CLZ32_MASK1): Delete.
+	(clz32_nz): Use __builtin_clz.
+	(ctz32_1bit): Delete.
+	(ctz32): Use __builtin_ctz.
+	(CLZ64_MASK32): Delete.
+	(CLZ64_MASK16): Delete.
+	(CLZ64_MASK8): Delete.
+	(CLZ64_MASK4): Delete.
+	(CLZ64_MASK2): Delete.
+	(CLZ64_MASK1): Delete.
+	(clz64_nz): Use __builtin_clzl.
+	(ctz64_1bit): Delete.
+	(ctz64): Use __builtin_ctzl.
+
+2022-05-20  Christophe Lyon  <christophe.lyon@arm.com>
+
+	* bid_gcc_intrinsics.h (LIBGCC2_HAS_HF_MODE): Define according to
+	__LIBGCC_HAS_HF_MODE__.
+	(BID_HAS_HF_MODE): Define.
+	(HFtype): Define.
+	(__bid_extendhfsd): New prototype.
+	(__bid_extendhfdd): Likewise.
+	(__bid_extendhftd): Likewise.
+	(__bid_truncsdhf): Likewise.
+	(__bid_truncddhf): Likewise.
+	(__bid_trunctdhf): Likewise.
+	* _dd_to_hf.c: New file.
+	* _hf_to_dd.c: New file.
+	* _hf_to_sd.c: New file.
+	* _hf_to_td.c: New file.
+	* _sd_to_hf.c: New file.
+	* _td_to_hf.c: New file.
+
+2022-05-20  Christophe Lyon  <christophe.lyon@arm.com>
+
+	* _dd_to_xf.c: Check __LIBGCC_HAS_XF_MODE__.
+	* _sd_to_xf.c: Likewise.
+	* _td_to_xf.c: Likewise.
+	* _xf_to_dd.c: Likewise.
+	* _xf_to_sd.c: Likewise.
+	* _xf_to_td.c: Likewise.
+
 2020-10-23  Jakub Jelinek  <jakub@redhat.com>
 
 	PR tree-optimization/97164
@@ -414,7 +462,7 @@
 	* inline_bid_add.h: Likewise.
 	* sqrt_macros.h: Likewise.
 
-Copyright (C) 2007-2021 Free Software Foundation, Inc.
+Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright

--- a/libbid/Makefile
+++ b/libbid/Makefile
@@ -11,7 +11,8 @@ libdfp_files += _addsub_dd _dd_to_sf _dd_to_xf _di_to_td _eq_td _gt_td \
 				_sd_to_dd _sd_to_tf _sf_to_td _td_to_di _td_to_usi _udi_to_sd \
 				_usi_to_sd _dd_to_sd _dd_to_usi _di_to_sd _eq_sd _gt_sd _le_sd \
 				_mul_sd _sd_to_df _sd_to_udi _si_to_dd _td_to_sd _td_to_xf \
-				_udi_to_td _usi_to_td
+				_udi_to_td _usi_to_td _dd_to_hf _hf_to_dd _hf_to_sd _hf_to_sd \
+				_hf_to_td _sd_to_hf _td_to_hf
 
 libdfp_files += bid_decimal_globals bid_decimal_data \
          bid_binarydecimal bid_convert_data \

--- a/libbid/README.libdfp
+++ b/libbid/README.libdfp
@@ -13,6 +13,7 @@ Next, scan for these and append hidden_def when we find
 the implementations (with GNU grep):
 
     for i in $(grep -oP "(?<=hidden_proto\()[^)]*" bid_gcc_intrinsics.h); do echo "hidden_def($i);" >> $(grep -e $i -l *c); done
+    for i in _*.c; do echo "$i"; vim -c "#endif\n\(hidden_def.*\)$/\1\r#endif/ge" -c "w" -c "qall" $i; done
 
 
 Likewise, ensure nothing is missing from the makefile,

--- a/libbid/_addsub_dd.c
+++ b/libbid/_addsub_dd.c
@@ -44,3 +44,5 @@ __bid_subdd3 (_Decimal64 x, _Decimal64 y) {
   res.i = __bid64_sub (ux.i, uy.i);
   return (res.d);
 }
+hidden_def(__bid_adddd3);
+hidden_def(__bid_subdd3);

--- a/libbid/_addsub_dd.c
+++ b/libbid/_addsub_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -44,5 +44,3 @@ __bid_subdd3 (_Decimal64 x, _Decimal64 y) {
   res.i = __bid64_sub (ux.i, uy.i);
   return (res.d);
 }
-hidden_def(__bid_adddd3);
-hidden_def(__bid_subdd3);

--- a/libbid/_addsub_sd.c
+++ b/libbid/_addsub_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -52,5 +52,3 @@ __bid_subsd3 (_Decimal32 x, _Decimal32 y) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_addsd3);
-hidden_def(__bid_subsd3);

--- a/libbid/_addsub_sd.c
+++ b/libbid/_addsub_sd.c
@@ -52,3 +52,5 @@ __bid_subsd3 (_Decimal32 x, _Decimal32 y) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_addsd3);
+hidden_def(__bid_subsd3);

--- a/libbid/_addsub_td.c
+++ b/libbid/_addsub_td.c
@@ -44,3 +44,5 @@ __bid_subtd3 (_Decimal128 x, _Decimal128 y) {
   res.i = __bid128_sub (ux.i, uy.i);
   return (res.d);
 }
+hidden_def(__bid_addtd3);
+hidden_def(__bid_subtd3);

--- a/libbid/_addsub_td.c
+++ b/libbid/_addsub_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -44,5 +44,3 @@ __bid_subtd3 (_Decimal128 x, _Decimal128 y) {
   res.i = __bid128_sub (ux.i, uy.i);
   return (res.d);
 }
-hidden_def(__bid_addtd3);
-hidden_def(__bid_subtd3);

--- a/libbid/_dd_to_df.c
+++ b/libbid/_dd_to_df.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_truncdddf (_Decimal64 x) {
   res = __bid64_to_binary64 (ux.i);
   return (res);
 }
-hidden_def(__bid_truncdddf);

--- a/libbid/_dd_to_df.c
+++ b/libbid/_dd_to_df.c
@@ -34,3 +34,4 @@ __bid_truncdddf (_Decimal64 x) {
   res = __bid64_to_binary64 (ux.i);
   return (res);
 }
+hidden_def(__bid_truncdddf);

--- a/libbid/_dd_to_di.c
+++ b/libbid/_dd_to_di.c
@@ -37,3 +37,4 @@ __bid_fixdddi (_Decimal64 x) {
 }
 
 
+hidden_def(__bid_fixdddi);

--- a/libbid/_dd_to_di.c
+++ b/libbid/_dd_to_di.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_fixdddi (_Decimal64 x) {
 }
 
 
-hidden_def(__bid_fixdddi);

--- a/libbid/_dd_to_hf.c
+++ b/libbid/_dd_to_hf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
+/* Copyright (C) 2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,11 +25,14 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
-_Decimal64
-__bid_floatunsdidd (UDItype x) {
-  union decimal64 res;
+#if LIBGCC2_HAS_HF_MODE || BID_HAS_HF_MODE
+HFtype
+__bid_truncddhf (_Decimal64 x) {
+  HFtype res;
+  union decimal64 ux;
 
-  res.i = __bid64_from_uint64 (x);
-  return (res.d);
+  ux.d = x;
+  res = __bid64_to_binary32 (ux.i);
+  return (res);
 }
-
+#endif

--- a/libbid/_dd_to_hf.c
+++ b/libbid/_dd_to_hf.c
@@ -35,4 +35,5 @@ __bid_truncddhf (_Decimal64 x) {
   res = __bid64_to_binary32 (ux.i);
   return (res);
 }
+hidden_def(__bid_truncddhf);
 #endif

--- a/libbid/_dd_to_sd.c
+++ b/libbid/_dd_to_sd.c
@@ -34,3 +34,4 @@ __bid_truncddsd2 (_Decimal64 x) {
   res.i = __bid64_to_bid32 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_truncddsd2);

--- a/libbid/_dd_to_sd.c
+++ b/libbid/_dd_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_truncddsd2 (_Decimal64 x) {
   res.i = __bid64_to_bid32 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_truncddsd2);

--- a/libbid/_dd_to_sf.c
+++ b/libbid/_dd_to_sf.c
@@ -34,3 +34,4 @@ __bid_truncddsf (_Decimal64 x) {
   res = __bid64_to_binary32 (ux.i);
   return (res);
 }
+hidden_def(__bid_truncddsf);

--- a/libbid/_dd_to_sf.c
+++ b/libbid/_dd_to_sf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_truncddsf (_Decimal64 x) {
   res = __bid64_to_binary32 (ux.i);
   return (res);
 }
-hidden_def(__bid_truncddsf);

--- a/libbid/_dd_to_si.c
+++ b/libbid/_dd_to_si.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_fixddsi (_Decimal64 x) {
 }
 
 
-hidden_def(__bid_fixddsi);

--- a/libbid/_dd_to_si.c
+++ b/libbid/_dd_to_si.c
@@ -37,3 +37,4 @@ __bid_fixddsi (_Decimal64 x) {
 }
 
 
+hidden_def(__bid_fixddsi);

--- a/libbid/_dd_to_td.c
+++ b/libbid/_dd_to_td.c
@@ -34,3 +34,4 @@ __bid_extendddtd2 (_Decimal64 x) {
   res.i = __bid64_to_bid128 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_extendddtd2);

--- a/libbid/_dd_to_td.c
+++ b/libbid/_dd_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_extendddtd2 (_Decimal64 x) {
   res.i = __bid64_to_bid128 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_extendddtd2);

--- a/libbid/_dd_to_tf.c
+++ b/libbid/_dd_to_tf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,5 +35,4 @@ __bid_extendddtf (_Decimal64 x) {
   res.i = __bid64_to_binary128 (ux.i);
   return (res.f);
 }
-hidden_def(__bid_extendddtf);
 #endif

--- a/libbid/_dd_to_tf.c
+++ b/libbid/_dd_to_tf.c
@@ -35,4 +35,5 @@ __bid_extendddtf (_Decimal64 x) {
   res.i = __bid64_to_binary128 (ux.i);
   return (res.f);
 }
+hidden_def(__bid_extendddtf);
 #endif

--- a/libbid/_dd_to_udi.c
+++ b/libbid/_dd_to_udi.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_fixunsdddi (_Decimal64 x) {
   return (res);
 }
 
-hidden_def(__bid_fixunsdddi);

--- a/libbid/_dd_to_udi.c
+++ b/libbid/_dd_to_udi.c
@@ -37,3 +37,4 @@ __bid_fixunsdddi (_Decimal64 x) {
   return (res);
 }
 
+hidden_def(__bid_fixunsdddi);

--- a/libbid/_dd_to_usi.c
+++ b/libbid/_dd_to_usi.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_fixunsddsi (_Decimal64 x) {
   return (res);
 }
 
-hidden_def(__bid_fixunsddsi);

--- a/libbid/_dd_to_usi.c
+++ b/libbid/_dd_to_usi.c
@@ -37,3 +37,4 @@ __bid_fixunsddsi (_Decimal64 x) {
   return (res);
 }
 
+hidden_def(__bid_fixunsddsi);

--- a/libbid/_dd_to_xf.c
+++ b/libbid/_dd_to_xf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,6 +25,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#ifdef __LIBGCC_HAS_XF_MODE__
 XFtype
 __bid_extendddxf (_Decimal64 x) {
   XFtype res;
@@ -34,4 +35,4 @@ __bid_extendddxf (_Decimal64 x) {
   res = __bid64_to_binary80 (ux.i);
   return (res);
 }
-hidden_def(__bid_extendddxf);
+#endif

--- a/libbid/_dd_to_xf.c
+++ b/libbid/_dd_to_xf.c
@@ -35,4 +35,5 @@ __bid_extendddxf (_Decimal64 x) {
   res = __bid64_to_binary80 (ux.i);
   return (res);
 }
+hidden_def(__bid_extendddxf);
 #endif

--- a/libbid/_df_to_dd.c
+++ b/libbid/_df_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -31,4 +31,3 @@ __bid_extenddfdd (DFtype x) {
   res.i = __binary64_to_bid64 (x);
   return (res.d);
 }
-hidden_def(__bid_extenddfdd);

--- a/libbid/_df_to_dd.c
+++ b/libbid/_df_to_dd.c
@@ -31,3 +31,4 @@ __bid_extenddfdd (DFtype x) {
   res.i = __binary64_to_bid64 (x);
   return (res.d);
 }
+hidden_def(__bid_extenddfdd);

--- a/libbid/_df_to_sd.c
+++ b/libbid/_df_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -32,4 +32,3 @@ __bid_truncdfsd (DFtype x) {
   res.i = __binary64_to_bid32 (x);
   return (res.d);
 }
-hidden_def(__bid_truncdfsd);

--- a/libbid/_df_to_sd.c
+++ b/libbid/_df_to_sd.c
@@ -32,3 +32,4 @@ __bid_truncdfsd (DFtype x) {
   res.i = __binary64_to_bid32 (x);
   return (res.d);
 }
+hidden_def(__bid_truncdfsd);

--- a/libbid/_df_to_td.c
+++ b/libbid/_df_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -31,4 +31,3 @@ __bid_extenddftd (DFtype x) {
   res.i = __binary64_to_bid128 (x);
   return (res.d);
 }
-hidden_def(__bid_extenddftd);

--- a/libbid/_df_to_td.c
+++ b/libbid/_df_to_td.c
@@ -31,3 +31,4 @@ __bid_extenddftd (DFtype x) {
   res.i = __binary64_to_bid128 (x);
   return (res.d);
 }
+hidden_def(__bid_extenddftd);

--- a/libbid/_di_to_dd.c
+++ b/libbid/_di_to_dd.c
@@ -33,3 +33,4 @@ __bid_floatdidd (DItype x) {
   return (res.d);
 }
 
+hidden_def(__bid_floatdidd);

--- a/libbid/_di_to_dd.c
+++ b/libbid/_di_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -33,4 +33,3 @@ __bid_floatdidd (DItype x) {
   return (res.d);
 }
 
-hidden_def(__bid_floatdidd);

--- a/libbid/_di_to_sd.c
+++ b/libbid/_di_to_sd.c
@@ -34,3 +34,4 @@ __bid_floatdisd (DItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_floatdisd);

--- a/libbid/_di_to_sd.c
+++ b/libbid/_di_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_floatdisd (DItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_floatdisd);

--- a/libbid/_di_to_td.c
+++ b/libbid/_di_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -33,4 +33,3 @@ __bid_floatditd (DItype x) {
   return (res.d);
 }
 
-hidden_def(__bid_floatditd);

--- a/libbid/_di_to_td.c
+++ b/libbid/_di_to_td.c
@@ -33,3 +33,4 @@ __bid_floatditd (DItype x) {
   return (res.d);
 }
 
+hidden_def(__bid_floatditd);

--- a/libbid/_div_dd.c
+++ b/libbid/_div_dd.c
@@ -34,3 +34,4 @@ __bid_divdd3 (_Decimal64 x, _Decimal64 y) {
   res.i = __bid64_div (ux.i, uy.i);
   return (res.d);
 }
+hidden_def(__bid_divdd3);

--- a/libbid/_div_dd.c
+++ b/libbid/_div_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_divdd3 (_Decimal64 x, _Decimal64 y) {
   res.i = __bid64_div (ux.i, uy.i);
   return (res.d);
 }
-hidden_def(__bid_divdd3);

--- a/libbid/_div_sd.c
+++ b/libbid/_div_sd.c
@@ -38,3 +38,4 @@ __bid_divsd3 (_Decimal32 x, _Decimal32 y) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_divsd3);

--- a/libbid/_div_sd.c
+++ b/libbid/_div_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -38,4 +38,3 @@ __bid_divsd3 (_Decimal32 x, _Decimal32 y) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_divsd3);

--- a/libbid/_div_td.c
+++ b/libbid/_div_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_divtd3 (_Decimal128 x, _Decimal128 y) {
   res.i = __bid128_div (ux.i, uy.i);
   return (res.d);
 }
-hidden_def(__bid_divtd3);

--- a/libbid/_div_td.c
+++ b/libbid/_div_td.c
@@ -34,3 +34,4 @@ __bid_divtd3 (_Decimal128 x, _Decimal128 y) {
   res.i = __bid128_div (ux.i, uy.i);
   return (res.d);
 }
+hidden_def(__bid_divtd3);

--- a/libbid/_eq_dd.c
+++ b/libbid/_eq_dd.c
@@ -39,3 +39,4 @@ __bid_eqdd2 (_Decimal64 x, _Decimal64 y) {
     res = 0;
   return (res);
 }
+hidden_def(__bid_eqdd2);

--- a/libbid/_eq_dd.c
+++ b/libbid/_eq_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_eqdd2 (_Decimal64 x, _Decimal64 y) {
     res = 0;
   return (res);
 }
-hidden_def(__bid_eqdd2);

--- a/libbid/_eq_sd.c
+++ b/libbid/_eq_sd.c
@@ -42,3 +42,4 @@ __bid_eqsd2 (_Decimal32 x, _Decimal32 y) {
     res = 0;
   return (res);
 }
+hidden_def(__bid_eqsd2);

--- a/libbid/_eq_sd.c
+++ b/libbid/_eq_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -42,4 +42,3 @@ __bid_eqsd2 (_Decimal32 x, _Decimal32 y) {
     res = 0;
   return (res);
 }
-hidden_def(__bid_eqsd2);

--- a/libbid/_eq_td.c
+++ b/libbid/_eq_td.c
@@ -39,3 +39,4 @@ __bid_eqtd2 (_Decimal128 x, _Decimal128 y) {
     res = 0;
   return (res);
 }
+hidden_def(__bid_eqtd2);

--- a/libbid/_eq_td.c
+++ b/libbid/_eq_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_eqtd2 (_Decimal128 x, _Decimal128 y) {
     res = 0;
   return (res);
 }
-hidden_def(__bid_eqtd2);

--- a/libbid/_ge_dd.c
+++ b/libbid/_ge_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_gedd2 (_Decimal64 x, _Decimal64 y) {
 
   return (res);
 }
-hidden_def(__bid_gedd2);

--- a/libbid/_ge_dd.c
+++ b/libbid/_ge_dd.c
@@ -37,3 +37,4 @@ __bid_gedd2 (_Decimal64 x, _Decimal64 y) {
 
   return (res);
 }
+hidden_def(__bid_gedd2);

--- a/libbid/_ge_sd.c
+++ b/libbid/_ge_sd.c
@@ -40,3 +40,4 @@ __bid_gesd2 (_Decimal32 x, _Decimal32 y) {
 
   return (res);
 }
+hidden_def(__bid_gesd2);

--- a/libbid/_ge_sd.c
+++ b/libbid/_ge_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -40,4 +40,3 @@ __bid_gesd2 (_Decimal32 x, _Decimal32 y) {
 
   return (res);
 }
-hidden_def(__bid_gesd2);

--- a/libbid/_ge_td.c
+++ b/libbid/_ge_td.c
@@ -37,3 +37,4 @@ __bid_getd2 (_Decimal128 x, _Decimal128 y) {
 
   return (res);
 }
+hidden_def(__bid_getd2);

--- a/libbid/_ge_td.c
+++ b/libbid/_ge_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_getd2 (_Decimal128 x, _Decimal128 y) {
 
   return (res);
 }
-hidden_def(__bid_getd2);

--- a/libbid/_gt_dd.c
+++ b/libbid/_gt_dd.c
@@ -35,3 +35,4 @@ __bid_gtdd2 (_Decimal64 x, _Decimal64 y) {
   res = __bid64_quiet_greater (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_gtdd2);

--- a/libbid/_gt_dd.c
+++ b/libbid/_gt_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_gtdd2 (_Decimal64 x, _Decimal64 y) {
   res = __bid64_quiet_greater (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_gtdd2);

--- a/libbid/_gt_sd.c
+++ b/libbid/_gt_sd.c
@@ -38,3 +38,4 @@ __bid_gtsd2 (_Decimal32 x, _Decimal32 y) {
   res = __bid64_quiet_greater (x64, y64);
   return (res);
 }
+hidden_def(__bid_gtsd2);

--- a/libbid/_gt_sd.c
+++ b/libbid/_gt_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -38,4 +38,3 @@ __bid_gtsd2 (_Decimal32 x, _Decimal32 y) {
   res = __bid64_quiet_greater (x64, y64);
   return (res);
 }
-hidden_def(__bid_gtsd2);

--- a/libbid/_gt_td.c
+++ b/libbid/_gt_td.c
@@ -35,3 +35,4 @@ __bid_gttd2 (_Decimal128 x, _Decimal128 y) {
   res = __bid128_quiet_greater (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_gttd2);

--- a/libbid/_gt_td.c
+++ b/libbid/_gt_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_gttd2 (_Decimal128 x, _Decimal128 y) {
   res = __bid128_quiet_greater (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_gttd2);

--- a/libbid/_hf_to_dd.c
+++ b/libbid/_hf_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
+/* Copyright (C) 2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,11 +25,12 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#if LIBGCC2_HAS_HF_MODE || BID_HAS_HF_MODE
 _Decimal64
-__bid_floatunsdidd (UDItype x) {
+__bid_extendhfdd (HFtype x) {
   union decimal64 res;
-
-  res.i = __bid64_from_uint64 (x);
+  SFtype xsf = x;
+  res.i = __binary32_to_bid64 (xsf);
   return (res.d);
 }
-
+#endif

--- a/libbid/_hf_to_dd.c
+++ b/libbid/_hf_to_dd.c
@@ -33,4 +33,5 @@ __bid_extendhfdd (HFtype x) {
   res.i = __binary32_to_bid64 (xsf);
   return (res.d);
 }
+hidden_def(__bid_extendhfdd);
 #endif

--- a/libbid/_hf_to_sd.c
+++ b/libbid/_hf_to_sd.c
@@ -33,4 +33,5 @@ __bid_extendhfsd (HFtype x) {
   res.i = __binary32_to_bid32 (xsf);
   return (res.d);
 }
+hidden_def(__bid_extendhfsd);
 #endif

--- a/libbid/_hf_to_sd.c
+++ b/libbid/_hf_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
+/* Copyright (C) 2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,11 +25,12 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
-_Decimal64
-__bid_floatunsdidd (UDItype x) {
-  union decimal64 res;
-
-  res.i = __bid64_from_uint64 (x);
+#if LIBGCC2_HAS_HF_MODE || BID_HAS_HF_MODE
+_Decimal32
+__bid_extendhfsd (HFtype x) {
+  union decimal32 res;
+  SFtype xsf = x;
+  res.i = __binary32_to_bid32 (xsf);
   return (res.d);
 }
-
+#endif

--- a/libbid/_hf_to_td.c
+++ b/libbid/_hf_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
+/* Copyright (C) 2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,11 +25,12 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
-_Decimal64
-__bid_floatunsdidd (UDItype x) {
-  union decimal64 res;
-
-  res.i = __bid64_from_uint64 (x);
+#if LIBGCC2_HAS_HF_MODE || BID_HAS_HF_MODE
+_Decimal128
+__bid_extendhftd (HFtype x) {
+  union decimal128 res;
+  SFtype xsf = x;
+  res.i = __binary32_to_bid128 (xsf);
   return (res.d);
 }
-
+#endif

--- a/libbid/_hf_to_td.c
+++ b/libbid/_hf_to_td.c
@@ -33,4 +33,5 @@ __bid_extendhftd (HFtype x) {
   res.i = __binary32_to_bid128 (xsf);
   return (res.d);
 }
+hidden_def(__bid_extendhftd);
 #endif

--- a/libbid/_isinfd128.c
+++ b/libbid/_isinfd128.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/_isinfd32.c
+++ b/libbid/_isinfd32.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/_isinfd64.c
+++ b/libbid/_isinfd64.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/_le_dd.c
+++ b/libbid/_le_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_ledd2 (_Decimal64 x, _Decimal64 y) {
     res = 1;
   return (res);
 }
-hidden_def(__bid_ledd2);

--- a/libbid/_le_dd.c
+++ b/libbid/_le_dd.c
@@ -39,3 +39,4 @@ __bid_ledd2 (_Decimal64 x, _Decimal64 y) {
     res = 1;
   return (res);
 }
+hidden_def(__bid_ledd2);

--- a/libbid/_le_sd.c
+++ b/libbid/_le_sd.c
@@ -42,3 +42,4 @@ __bid_lesd2 (_Decimal32 x, _Decimal32 y) {
     res = 1;
   return (res);
 }
+hidden_def(__bid_lesd2);

--- a/libbid/_le_sd.c
+++ b/libbid/_le_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -42,4 +42,3 @@ __bid_lesd2 (_Decimal32 x, _Decimal32 y) {
     res = 1;
   return (res);
 }
-hidden_def(__bid_lesd2);

--- a/libbid/_le_td.c
+++ b/libbid/_le_td.c
@@ -39,3 +39,4 @@ __bid_letd2 (_Decimal128 x, _Decimal128 y) {
     res = 1;
   return (res);
 }
+hidden_def(__bid_letd2);

--- a/libbid/_le_td.c
+++ b/libbid/_le_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_letd2 (_Decimal128 x, _Decimal128 y) {
     res = 1;
   return (res);
 }
-hidden_def(__bid_letd2);

--- a/libbid/_lt_dd.c
+++ b/libbid/_lt_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_ltdd2 (_Decimal64 x, _Decimal64 y) {
   res = -__bid64_quiet_less (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_ltdd2);

--- a/libbid/_lt_dd.c
+++ b/libbid/_lt_dd.c
@@ -35,3 +35,4 @@ __bid_ltdd2 (_Decimal64 x, _Decimal64 y) {
   res = -__bid64_quiet_less (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_ltdd2);

--- a/libbid/_lt_sd.c
+++ b/libbid/_lt_sd.c
@@ -38,3 +38,4 @@ __bid_ltsd2 (_Decimal32 x, _Decimal32 y) {
   res = -__bid64_quiet_less (x64, y64);
   return (res);
 }
+hidden_def(__bid_ltsd2);

--- a/libbid/_lt_sd.c
+++ b/libbid/_lt_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -38,4 +38,3 @@ __bid_ltsd2 (_Decimal32 x, _Decimal32 y) {
   res = -__bid64_quiet_less (x64, y64);
   return (res);
 }
-hidden_def(__bid_ltsd2);

--- a/libbid/_lt_td.c
+++ b/libbid/_lt_td.c
@@ -35,3 +35,4 @@ __bid_lttd2 (_Decimal128 x, _Decimal128 y) {
   res = -__bid128_quiet_less (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_lttd2);

--- a/libbid/_lt_td.c
+++ b/libbid/_lt_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_lttd2 (_Decimal128 x, _Decimal128 y) {
   res = -__bid128_quiet_less (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_lttd2);

--- a/libbid/_mul_dd.c
+++ b/libbid/_mul_dd.c
@@ -34,3 +34,4 @@ __bid_muldd3 (_Decimal64 x, _Decimal64 y) {
   res.i = __bid64_mul (ux.i, uy.i);
   return (res.d);
 }
+hidden_def(__bid_muldd3);

--- a/libbid/_mul_dd.c
+++ b/libbid/_mul_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_muldd3 (_Decimal64 x, _Decimal64 y) {
   res.i = __bid64_mul (ux.i, uy.i);
   return (res.d);
 }
-hidden_def(__bid_muldd3);

--- a/libbid/_mul_sd.c
+++ b/libbid/_mul_sd.c
@@ -38,3 +38,4 @@ __bid_mulsd3 (_Decimal32 x, _Decimal32 y) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_mulsd3);

--- a/libbid/_mul_sd.c
+++ b/libbid/_mul_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -38,4 +38,3 @@ __bid_mulsd3 (_Decimal32 x, _Decimal32 y) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_mulsd3);

--- a/libbid/_mul_td.c
+++ b/libbid/_mul_td.c
@@ -34,3 +34,4 @@ __bid_multd3 (_Decimal128 x, _Decimal128 y) {
   res.i = __bid128_mul (ux.i, uy.i);
   return (res.d);
 }
+hidden_def(__bid_multd3);

--- a/libbid/_mul_td.c
+++ b/libbid/_mul_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_multd3 (_Decimal128 x, _Decimal128 y) {
   res.i = __bid128_mul (ux.i, uy.i);
   return (res.d);
 }
-hidden_def(__bid_multd3);

--- a/libbid/_ne_dd.c
+++ b/libbid/_ne_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_nedd2 (_Decimal64 x, _Decimal64 y) {
   res = __bid64_quiet_not_equal (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_nedd2);

--- a/libbid/_ne_dd.c
+++ b/libbid/_ne_dd.c
@@ -35,3 +35,4 @@ __bid_nedd2 (_Decimal64 x, _Decimal64 y) {
   res = __bid64_quiet_not_equal (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_nedd2);

--- a/libbid/_ne_sd.c
+++ b/libbid/_ne_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -38,4 +38,3 @@ __bid_nesd2 (_Decimal32 x, _Decimal32 y) {
   res = __bid64_quiet_not_equal (x64, y64);
   return (res);
 }
-hidden_def(__bid_nesd2);

--- a/libbid/_ne_sd.c
+++ b/libbid/_ne_sd.c
@@ -38,3 +38,4 @@ __bid_nesd2 (_Decimal32 x, _Decimal32 y) {
   res = __bid64_quiet_not_equal (x64, y64);
   return (res);
 }
+hidden_def(__bid_nesd2);

--- a/libbid/_ne_td.c
+++ b/libbid/_ne_td.c
@@ -35,3 +35,4 @@ __bid_netd2 (_Decimal128 x, _Decimal128 y) {
   res = __bid128_quiet_not_equal (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_netd2);

--- a/libbid/_ne_td.c
+++ b/libbid/_ne_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_netd2 (_Decimal128 x, _Decimal128 y) {
   res = __bid128_quiet_not_equal (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_netd2);

--- a/libbid/_sd_to_dd.c
+++ b/libbid/_sd_to_dd.c
@@ -34,3 +34,4 @@ __bid_extendsddd2 (_Decimal32 x) {
   res.i = __bid32_to_bid64 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_extendsddd2);

--- a/libbid/_sd_to_dd.c
+++ b/libbid/_sd_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_extendsddd2 (_Decimal32 x) {
   res.i = __bid32_to_bid64 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_extendsddd2);

--- a/libbid/_sd_to_df.c
+++ b/libbid/_sd_to_df.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_extendsddf (_Decimal32 x) {
   res = __bid32_to_binary64 (ux.i);
   return (res);
 }
-hidden_def(__bid_extendsddf);

--- a/libbid/_sd_to_df.c
+++ b/libbid/_sd_to_df.c
@@ -34,3 +34,4 @@ __bid_extendsddf (_Decimal32 x) {
   res = __bid32_to_binary64 (ux.i);
   return (res);
 }
+hidden_def(__bid_extendsddf);

--- a/libbid/_sd_to_di.c
+++ b/libbid/_sd_to_di.c
@@ -39,3 +39,4 @@ __bid_fixsddi (_Decimal32 x) {
 }
 
 
+hidden_def(__bid_fixsddi);

--- a/libbid/_sd_to_di.c
+++ b/libbid/_sd_to_di.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_fixsddi (_Decimal32 x) {
 }
 
 
-hidden_def(__bid_fixsddi);

--- a/libbid/_sd_to_hf.c
+++ b/libbid/_sd_to_hf.c
@@ -35,4 +35,5 @@ __bid_truncsdhf (_Decimal32 x) {
   res = __bid32_to_binary32 (ux.i);
   return (res);
 }
+hidden_def(__bid_truncsdhf);
 #endif

--- a/libbid/_sd_to_hf.c
+++ b/libbid/_sd_to_hf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
+/* Copyright (C) 2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,11 +25,14 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
-_Decimal64
-__bid_floatunsdidd (UDItype x) {
-  union decimal64 res;
+#if LIBGCC2_HAS_HF_MODE || BID_HAS_HF_MODE
+HFtype
+__bid_truncsdhf (_Decimal32 x) {
+  HFtype res;
+  union decimal32 ux;
 
-  res.i = __bid64_from_uint64 (x);
-  return (res.d);
+  ux.d = x;
+  res = __bid32_to_binary32 (ux.i);
+  return (res);
 }
-
+#endif

--- a/libbid/_sd_to_sf.c
+++ b/libbid/_sd_to_sf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_truncsdsf (_Decimal32 x) {
   res = __bid32_to_binary32 (ux.i);
   return (res);
 }
-hidden_def(__bid_truncsdsf);

--- a/libbid/_sd_to_sf.c
+++ b/libbid/_sd_to_sf.c
@@ -34,3 +34,4 @@ __bid_truncsdsf (_Decimal32 x) {
   res = __bid32_to_binary32 (ux.i);
   return (res);
 }
+hidden_def(__bid_truncsdsf);

--- a/libbid/_sd_to_si.c
+++ b/libbid/_sd_to_si.c
@@ -39,3 +39,4 @@ __bid_fixsdsi (_Decimal32 x) {
 }
 
 
+hidden_def(__bid_fixsdsi);

--- a/libbid/_sd_to_si.c
+++ b/libbid/_sd_to_si.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_fixsdsi (_Decimal32 x) {
 }
 
 
-hidden_def(__bid_fixsdsi);

--- a/libbid/_sd_to_td.c
+++ b/libbid/_sd_to_td.c
@@ -34,3 +34,4 @@ __bid_extendsdtd2 (_Decimal32 x) {
   res.i = __bid32_to_bid128 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_extendsdtd2);

--- a/libbid/_sd_to_td.c
+++ b/libbid/_sd_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_extendsdtd2 (_Decimal32 x) {
   res.i = __bid32_to_bid128 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_extendsdtd2);

--- a/libbid/_sd_to_tf.c
+++ b/libbid/_sd_to_tf.c
@@ -35,4 +35,5 @@ __bid_extendsdtf (_Decimal32 x) {
   res.i = __bid32_to_binary128 (ux.i);
   return (res.f);
 }
+hidden_def(__bid_extendsdtf);
 #endif

--- a/libbid/_sd_to_tf.c
+++ b/libbid/_sd_to_tf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,5 +35,4 @@ __bid_extendsdtf (_Decimal32 x) {
   res.i = __bid32_to_binary128 (ux.i);
   return (res.f);
 }
-hidden_def(__bid_extendsdtf);
 #endif

--- a/libbid/_sd_to_udi.c
+++ b/libbid/_sd_to_udi.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_fixunssddi (_Decimal32 x) {
   return (res);
 }
 
-hidden_def(__bid_fixunssddi);

--- a/libbid/_sd_to_udi.c
+++ b/libbid/_sd_to_udi.c
@@ -39,3 +39,4 @@ __bid_fixunssddi (_Decimal32 x) {
   return (res);
 }
 
+hidden_def(__bid_fixunssddi);

--- a/libbid/_sd_to_usi.c
+++ b/libbid/_sd_to_usi.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_fixunssdsi (_Decimal32 x) {
   return (res);
 }
 
-hidden_def(__bid_fixunssdsi);

--- a/libbid/_sd_to_usi.c
+++ b/libbid/_sd_to_usi.c
@@ -39,3 +39,4 @@ __bid_fixunssdsi (_Decimal32 x) {
   return (res);
 }
 
+hidden_def(__bid_fixunssdsi);

--- a/libbid/_sd_to_xf.c
+++ b/libbid/_sd_to_xf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,6 +25,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#ifdef __LIBGCC_HAS_XF_MODE__
 XFtype
 __bid_extendsdxf (_Decimal32 x) {
   XFtype res;
@@ -34,4 +35,4 @@ __bid_extendsdxf (_Decimal32 x) {
   res = __bid32_to_binary80 (ux.i);
   return (res);
 }
-hidden_def(__bid_extendsdxf);
+#endif

--- a/libbid/_sd_to_xf.c
+++ b/libbid/_sd_to_xf.c
@@ -35,4 +35,5 @@ __bid_extendsdxf (_Decimal32 x) {
   res = __bid32_to_binary80 (ux.i);
   return (res);
 }
+hidden_def(__bid_extendsdxf);
 #endif

--- a/libbid/_sf_to_dd.c
+++ b/libbid/_sf_to_dd.c
@@ -31,3 +31,4 @@ __bid_extendsfdd (SFtype x) {
   res.i = __binary32_to_bid64 (x);
   return (res.d);
 }
+hidden_def(__bid_extendsfdd);

--- a/libbid/_sf_to_dd.c
+++ b/libbid/_sf_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -31,4 +31,3 @@ __bid_extendsfdd (SFtype x) {
   res.i = __binary32_to_bid64 (x);
   return (res.d);
 }
-hidden_def(__bid_extendsfdd);

--- a/libbid/_sf_to_sd.c
+++ b/libbid/_sf_to_sd.c
@@ -31,3 +31,4 @@ __bid_extendsfsd (SFtype x) {
   res.i = __binary32_to_bid32 (x);
   return (res.d);
 }
+hidden_def(__bid_extendsfsd);

--- a/libbid/_sf_to_sd.c
+++ b/libbid/_sf_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -31,4 +31,3 @@ __bid_extendsfsd (SFtype x) {
   res.i = __binary32_to_bid32 (x);
   return (res.d);
 }
-hidden_def(__bid_extendsfsd);

--- a/libbid/_sf_to_td.c
+++ b/libbid/_sf_to_td.c
@@ -31,3 +31,4 @@ __bid_extendsftd (SFtype x) {
   res.i = __binary32_to_bid128 (x);
   return (res.d);
 }
+hidden_def(__bid_extendsftd);

--- a/libbid/_sf_to_td.c
+++ b/libbid/_sf_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -31,4 +31,3 @@ __bid_extendsftd (SFtype x) {
   res.i = __binary32_to_bid128 (x);
   return (res.d);
 }
-hidden_def(__bid_extendsftd);

--- a/libbid/_si_to_dd.c
+++ b/libbid/_si_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -32,4 +32,3 @@ __bid_floatsidd (SItype x) {
   res.i = __bid64_from_int32 (x);
   return (res.d);
 }
-hidden_def(__bid_floatsidd);

--- a/libbid/_si_to_dd.c
+++ b/libbid/_si_to_dd.c
@@ -32,3 +32,4 @@ __bid_floatsidd (SItype x) {
   res.i = __bid64_from_int32 (x);
   return (res.d);
 }
+hidden_def(__bid_floatsidd);

--- a/libbid/_si_to_sd.c
+++ b/libbid/_si_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_floatsisd (SItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_floatsisd);

--- a/libbid/_si_to_sd.c
+++ b/libbid/_si_to_sd.c
@@ -34,3 +34,4 @@ __bid_floatsisd (SItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_floatsisd);

--- a/libbid/_si_to_td.c
+++ b/libbid/_si_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -32,4 +32,3 @@ __bid_floatsitd (SItype x) {
   res.i = __bid128_from_int32 (x);
   return (res.d);
 }
-hidden_def(__bid_floatsitd);

--- a/libbid/_si_to_td.c
+++ b/libbid/_si_to_td.c
@@ -32,3 +32,4 @@ __bid_floatsitd (SItype x) {
   res.i = __bid128_from_int32 (x);
   return (res.d);
 }
+hidden_def(__bid_floatsitd);

--- a/libbid/_td_to_dd.c
+++ b/libbid/_td_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_trunctddd2 (_Decimal128 x) {
   res.i = __bid128_to_bid64 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_trunctddd2);

--- a/libbid/_td_to_dd.c
+++ b/libbid/_td_to_dd.c
@@ -34,3 +34,4 @@ __bid_trunctddd2 (_Decimal128 x) {
   res.i = __bid128_to_bid64 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_trunctddd2);

--- a/libbid/_td_to_df.c
+++ b/libbid/_td_to_df.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_trunctddf (_Decimal128 x) {
   res = __bid128_to_binary64 (ux.i);
   return (res);
 }
-hidden_def(__bid_trunctddf);

--- a/libbid/_td_to_df.c
+++ b/libbid/_td_to_df.c
@@ -34,3 +34,4 @@ __bid_trunctddf (_Decimal128 x) {
   res = __bid128_to_binary64 (ux.i);
   return (res);
 }
+hidden_def(__bid_trunctddf);

--- a/libbid/_td_to_di.c
+++ b/libbid/_td_to_di.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -37,4 +37,3 @@ __bid_fixtddi (_Decimal128 x) {
 }
 
 
-hidden_def(__bid_fixtddi);

--- a/libbid/_td_to_di.c
+++ b/libbid/_td_to_di.c
@@ -37,3 +37,4 @@ __bid_fixtddi (_Decimal128 x) {
 }
 
 
+hidden_def(__bid_fixtddi);

--- a/libbid/_td_to_hf.c
+++ b/libbid/_td_to_hf.c
@@ -35,4 +35,5 @@ __bid_trunctdhf (_Decimal128 x) {
   res = __bid128_to_binary32 (ux.i);
   return (res);
 }
+hidden_def(__bid_trunctdhf);
 #endif

--- a/libbid/_td_to_hf.c
+++ b/libbid/_td_to_hf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
+/* Copyright (C) 2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,11 +25,14 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
-_Decimal64
-__bid_floatunsdidd (UDItype x) {
-  union decimal64 res;
+#if LIBGCC2_HAS_HF_MODE || BID_HAS_HF_MODE
+HFtype
+__bid_trunctdhf (_Decimal128 x) {
+  HFtype res;
+  union decimal128 ux;
 
-  res.i = __bid64_from_uint64 (x);
-  return (res.d);
+  ux.d = x;
+  res = __bid128_to_binary32 (ux.i);
+  return (res);
 }
-
+#endif

--- a/libbid/_td_to_sd.c
+++ b/libbid/_td_to_sd.c
@@ -34,3 +34,4 @@ __bid_trunctdsd2 (_Decimal128 x) {
   res.i = __bid128_to_bid32 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_trunctdsd2);

--- a/libbid/_td_to_sd.c
+++ b/libbid/_td_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_trunctdsd2 (_Decimal128 x) {
   res.i = __bid128_to_bid32 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_trunctdsd2);

--- a/libbid/_td_to_sf.c
+++ b/libbid/_td_to_sf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_trunctdsf (_Decimal128 x) {
   res = __bid128_to_binary32 (ux.i);
   return (res);
 }
-hidden_def(__bid_trunctdsf);

--- a/libbid/_td_to_sf.c
+++ b/libbid/_td_to_sf.c
@@ -34,3 +34,4 @@ __bid_trunctdsf (_Decimal128 x) {
   res = __bid128_to_binary32 (ux.i);
   return (res);
 }
+hidden_def(__bid_trunctdsf);

--- a/libbid/_td_to_si.c
+++ b/libbid/_td_to_si.c
@@ -36,3 +36,4 @@ __bid_fixtdsi (_Decimal128 x) {
   return (res);
 }
 
+hidden_def(__bid_fixtdsi);

--- a/libbid/_td_to_si.c
+++ b/libbid/_td_to_si.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -36,4 +36,3 @@ __bid_fixtdsi (_Decimal128 x) {
   return (res);
 }
 
-hidden_def(__bid_fixtdsi);

--- a/libbid/_td_to_tf.c
+++ b/libbid/_td_to_tf.c
@@ -35,4 +35,5 @@ __bid_trunctdtf (_Decimal128 x) {
   res.i = __bid128_to_binary128 (ux.i);
   return (res.f);
 }
+hidden_def(__bid_trunctdtf);
 #endif

--- a/libbid/_td_to_tf.c
+++ b/libbid/_td_to_tf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,5 +35,4 @@ __bid_trunctdtf (_Decimal128 x) {
   res.i = __bid128_to_binary128 (ux.i);
   return (res.f);
 }
-hidden_def(__bid_trunctdtf);
 #endif

--- a/libbid/_td_to_udi.c
+++ b/libbid/_td_to_udi.c
@@ -39,3 +39,4 @@ __bid_fixunstddi (_Decimal128 x) {
 }
 
 
+hidden_def(__bid_fixunstddi);

--- a/libbid/_td_to_udi.c
+++ b/libbid/_td_to_udi.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_fixunstddi (_Decimal128 x) {
 }
 
 
-hidden_def(__bid_fixunstddi);

--- a/libbid/_td_to_usi.c
+++ b/libbid/_td_to_usi.c
@@ -38,3 +38,4 @@ __bid_fixunstdsi (_Decimal128 x) {
 }
 
 
+hidden_def(__bid_fixunstdsi);

--- a/libbid/_td_to_usi.c
+++ b/libbid/_td_to_usi.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -38,4 +38,3 @@ __bid_fixunstdsi (_Decimal128 x) {
 }
 
 
-hidden_def(__bid_fixunstdsi);

--- a/libbid/_td_to_xf.c
+++ b/libbid/_td_to_xf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,6 +25,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#ifdef __LIBGCC_HAS_XF_MODE__
 XFtype
 __bid_trunctdxf (_Decimal128 x) {
   XFtype res;
@@ -34,4 +35,4 @@ __bid_trunctdxf (_Decimal128 x) {
   res = __bid128_to_binary80 (ux.i);
   return (res);
 }
-hidden_def(__bid_trunctdxf);
+#endif

--- a/libbid/_td_to_xf.c
+++ b/libbid/_td_to_xf.c
@@ -35,4 +35,5 @@ __bid_trunctdxf (_Decimal128 x) {
   res = __bid128_to_binary80 (ux.i);
   return (res);
 }
+hidden_def(__bid_trunctdxf);
 #endif

--- a/libbid/_tf_to_dd.c
+++ b/libbid/_tf_to_dd.c
@@ -35,4 +35,5 @@ __bid_trunctfdd (TFtype x) {
   res.i = __binary128_to_bid64 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_trunctfdd);
 #endif

--- a/libbid/_tf_to_dd.c
+++ b/libbid/_tf_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,5 +35,4 @@ __bid_trunctfdd (TFtype x) {
   res.i = __binary128_to_bid64 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_trunctfdd);
 #endif

--- a/libbid/_tf_to_sd.c
+++ b/libbid/_tf_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,5 +35,4 @@ __bid_trunctfsd (TFtype x) {
   res.i = __binary128_to_bid32 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_trunctfsd);
 #endif

--- a/libbid/_tf_to_sd.c
+++ b/libbid/_tf_to_sd.c
@@ -35,4 +35,5 @@ __bid_trunctfsd (TFtype x) {
   res.i = __binary128_to_bid32 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_trunctfsd);
 #endif

--- a/libbid/_tf_to_td.c
+++ b/libbid/_tf_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,5 +35,4 @@ __bid_extendtftd (TFtype x) {
   res.i = __binary128_to_bid128 (ux.i);
   return (res.d);
 }
-hidden_def(__bid_extendtftd);
 #endif

--- a/libbid/_tf_to_td.c
+++ b/libbid/_tf_to_td.c
@@ -35,4 +35,5 @@ __bid_extendtftd (TFtype x) {
   res.i = __binary128_to_bid128 (ux.i);
   return (res.d);
 }
+hidden_def(__bid_extendtftd);
 #endif

--- a/libbid/_udi_to_dd.c
+++ b/libbid/_udi_to_dd.c
@@ -33,3 +33,4 @@ __bid_floatunsdidd (UDItype x) {
   return (res.d);
 }
 
+hidden_def(__bid_floatunsdidd);

--- a/libbid/_udi_to_sd.c
+++ b/libbid/_udi_to_sd.c
@@ -34,3 +34,4 @@ __bid_floatunsdisd (UDItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_floatunsdisd);

--- a/libbid/_udi_to_sd.c
+++ b/libbid/_udi_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_floatunsdisd (UDItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_floatunsdisd);

--- a/libbid/_udi_to_td.c
+++ b/libbid/_udi_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -33,4 +33,3 @@ __bid_floatunsditd (UDItype x) {
   return (res.d);
 }
 
-hidden_def(__bid_floatunsditd);

--- a/libbid/_udi_to_td.c
+++ b/libbid/_udi_to_td.c
@@ -33,3 +33,4 @@ __bid_floatunsditd (UDItype x) {
   return (res.d);
 }
 
+hidden_def(__bid_floatunsditd);

--- a/libbid/_unord_dd.c
+++ b/libbid/_unord_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_unorddd2 (_Decimal64 x, _Decimal64 y) {
   res = __bid64_quiet_unordered (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_unorddd2);

--- a/libbid/_unord_dd.c
+++ b/libbid/_unord_dd.c
@@ -35,3 +35,4 @@ __bid_unorddd2 (_Decimal64 x, _Decimal64 y) {
   res = __bid64_quiet_unordered (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_unorddd2);

--- a/libbid/_unord_sd.c
+++ b/libbid/_unord_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -39,4 +39,3 @@ __bid_unordsd2 (_Decimal32 x, _Decimal32 y) {
   return (res);
 }
 
-hidden_def(__bid_unordsd2);

--- a/libbid/_unord_sd.c
+++ b/libbid/_unord_sd.c
@@ -39,3 +39,4 @@ __bid_unordsd2 (_Decimal32 x, _Decimal32 y) {
   return (res);
 }
 
+hidden_def(__bid_unordsd2);

--- a/libbid/_unord_td.c
+++ b/libbid/_unord_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -35,4 +35,3 @@ __bid_unordtd2 (_Decimal128 x, _Decimal128 y) {
   res = __bid128_quiet_unordered (ux.i, uy.i);
   return (res);
 }
-hidden_def(__bid_unordtd2);

--- a/libbid/_unord_td.c
+++ b/libbid/_unord_td.c
@@ -35,3 +35,4 @@ __bid_unordtd2 (_Decimal128 x, _Decimal128 y) {
   res = __bid128_quiet_unordered (ux.i, uy.i);
   return (res);
 }
+hidden_def(__bid_unordtd2);

--- a/libbid/_usi_to_dd.c
+++ b/libbid/_usi_to_dd.c
@@ -33,3 +33,4 @@ __bid_floatunssidd (USItype x) {
   return (res.d);
 }
 
+hidden_def(__bid_floatunssidd);

--- a/libbid/_usi_to_dd.c
+++ b/libbid/_usi_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -33,4 +33,3 @@ __bid_floatunssidd (USItype x) {
   return (res.d);
 }
 
-hidden_def(__bid_floatunssidd);

--- a/libbid/_usi_to_sd.c
+++ b/libbid/_usi_to_sd.c
@@ -34,3 +34,4 @@ __bid_floatunssisd (USItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
+hidden_def(__bid_floatunssisd);

--- a/libbid/_usi_to_sd.c
+++ b/libbid/_usi_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -34,4 +34,3 @@ __bid_floatunssisd (USItype x) {
   res.i = __bid64_to_bid32 (res64);
   return (res.d);
 }
-hidden_def(__bid_floatunssisd);

--- a/libbid/_usi_to_td.c
+++ b/libbid/_usi_to_td.c
@@ -33,3 +33,4 @@ __bid_floatunssitd (USItype x) {
   return (res.d);
 }
 
+hidden_def(__bid_floatunssitd);

--- a/libbid/_usi_to_td.c
+++ b/libbid/_usi_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -33,4 +33,3 @@ __bid_floatunssitd (USItype x) {
   return (res.d);
 }
 
-hidden_def(__bid_floatunssitd);

--- a/libbid/_xf_to_dd.c
+++ b/libbid/_xf_to_dd.c
@@ -32,4 +32,5 @@ __bid_truncxfdd (XFtype x) {
   res.i = __binary80_to_bid64 (x);
   return (res.d);
 }
+hidden_def(__bid_truncxfdd);
 #endif

--- a/libbid/_xf_to_dd.c
+++ b/libbid/_xf_to_dd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,10 +25,11 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#ifdef __LIBGCC_HAS_XF_MODE__
 _Decimal64
 __bid_truncxfdd (XFtype x) {
   union decimal64 res;
   res.i = __binary80_to_bid64 (x);
   return (res.d);
 }
-hidden_def(__bid_truncxfdd);
+#endif

--- a/libbid/_xf_to_sd.c
+++ b/libbid/_xf_to_sd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,10 +25,11 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#ifdef __LIBGCC_HAS_XF_MODE__
 _Decimal32
 __bid_truncxfsd (XFtype x) {
   union decimal32 res;
   res.i = __binary80_to_bid32 (x);
   return (res.d);
 }
-hidden_def(__bid_truncxfsd);
+#endif

--- a/libbid/_xf_to_sd.c
+++ b/libbid/_xf_to_sd.c
@@ -32,4 +32,5 @@ __bid_truncxfsd (XFtype x) {
   res.i = __binary80_to_bid32 (x);
   return (res.d);
 }
+hidden_def(__bid_truncxfsd);
 #endif

--- a/libbid/_xf_to_td.c
+++ b/libbid/_xf_to_td.c
@@ -32,4 +32,5 @@ __bid_extendxftd (XFtype x) {
   res.i = __binary80_to_bid128 (x);
   return (res.d);
 }
+hidden_def(__bid_extendxftd);
 #endif

--- a/libbid/_xf_to_td.c
+++ b/libbid/_xf_to_td.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -25,10 +25,11 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "bid_functions.h"
 #include "bid_gcc_intrinsics.h"
 
+#ifdef __LIBGCC_HAS_XF_MODE__
 _Decimal128
 __bid_extendxftd (XFtype x) {
   union decimal128 res;
   res.i = __binary80_to_bid128 (x);
   return (res.d);
 }
-hidden_def(__bid_extendxftd);
+#endif

--- a/libbid/bid128.c
+++ b/libbid/bid128.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_2_str.h
+++ b/libbid/bid128_2_str.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_2_str_macros.h
+++ b/libbid/bid128_2_str_macros.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_2_str_tables.c
+++ b/libbid/bid128_2_str_tables.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_add.c
+++ b/libbid/bid128_add.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_compare.c
+++ b/libbid/bid128_compare.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_div.c
+++ b/libbid/bid128_div.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_fma.c
+++ b/libbid/bid128_fma.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_logb.c
+++ b/libbid/bid128_logb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_minmax.c
+++ b/libbid/bid128_minmax.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_mul.c
+++ b/libbid/bid128_mul.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_next.c
+++ b/libbid/bid128_next.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_noncomp.c
+++ b/libbid/bid128_noncomp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_quantize.c
+++ b/libbid/bid128_quantize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_rem.c
+++ b/libbid/bid128_rem.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_round_integral.c
+++ b/libbid/bid128_round_integral.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_scalb.c
+++ b/libbid/bid128_scalb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_sqrt.c
+++ b/libbid/bid128_sqrt.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_string.c
+++ b/libbid/bid128_string.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_int16.c
+++ b/libbid/bid128_to_int16.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_int32.c
+++ b/libbid/bid128_to_int32.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_int64.c
+++ b/libbid/bid128_to_int64.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_int8.c
+++ b/libbid/bid128_to_int8.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_uint16.c
+++ b/libbid/bid128_to_uint16.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_uint32.c
+++ b/libbid/bid128_to_uint32.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_uint64.c
+++ b/libbid/bid128_to_uint64.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid128_to_uint8.c
+++ b/libbid/bid128_to_uint8.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid32_to_bid128.c
+++ b/libbid/bid32_to_bid128.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid32_to_bid64.c
+++ b/libbid/bid32_to_bid64.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_add.c
+++ b/libbid/bid64_add.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_compare.c
+++ b/libbid/bid64_compare.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_div.c
+++ b/libbid/bid64_div.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_fma.c
+++ b/libbid/bid64_fma.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_logb.c
+++ b/libbid/bid64_logb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_minmax.c
+++ b/libbid/bid64_minmax.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_mul.c
+++ b/libbid/bid64_mul.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_next.c
+++ b/libbid/bid64_next.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_noncomp.c
+++ b/libbid/bid64_noncomp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_quantize.c
+++ b/libbid/bid64_quantize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_rem.c
+++ b/libbid/bid64_rem.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_round_integral.c
+++ b/libbid/bid64_round_integral.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_scalb.c
+++ b/libbid/bid64_scalb.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_sqrt.c
+++ b/libbid/bid64_sqrt.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_string.c
+++ b/libbid/bid64_string.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_bid128.c
+++ b/libbid/bid64_to_bid128.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_int16.c
+++ b/libbid/bid64_to_int16.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_int32.c
+++ b/libbid/bid64_to_int32.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_int64.c
+++ b/libbid/bid64_to_int64.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_int8.c
+++ b/libbid/bid64_to_int8.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_uint16.c
+++ b/libbid/bid64_to_uint16.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_uint32.c
+++ b/libbid/bid64_to_uint32.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_uint64.c
+++ b/libbid/bid64_to_uint64.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid64_to_uint8.c
+++ b/libbid/bid64_to_uint8.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_b2d.h
+++ b/libbid/bid_b2d.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_conf.h
+++ b/libbid/bid_conf.h
@@ -534,6 +534,29 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #define BID_HAS_GCC_DECIMAL_INTRINSICS 1
 #endif /* IN_LIBGCC2 */
 
+// We are in libdfp.
+#ifndef BID_BIG_ENDIAN
+#define BID_BIG_ENDIAN __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__
+#endif
+
+#ifndef BID_THREAD
+#if defined (HAVE_CC_TLS) && defined (USE_TLS)
+#define BID_THREAD __thread
+#endif
+#endif
+
+#define _intptr_t_defined
+#define DECIMAL_CALL_BY_REFERENCE 0
+#define DECIMAL_GLOBAL_ROUNDING 1
+#define DECIMAL_GLOBAL_ROUNDING_ACCESS_FUNCTIONS 1
+#define DECIMAL_GLOBAL_EXCEPTION_FLAGS 1
+#define DECIMAL_GLOBAL_EXCEPTION_FLAGS_ACCESS_FUNCTIONS 1
+#define BID_HAS_GCC_DECIMAL_INTRINSICS 1
+extern void __dfp_set_status (int excepts);
+// Use a statement expression (GNU C) to quiet warnings
+#define __set_status_flags(fpsc, status) ({ __dfp_set_status(status); (void)fpsc; })
+// End libdfp options
+
 // Configuration Options
 
 #define SET_STATUS_FLAGS

--- a/libbid/bid_conf.h
+++ b/libbid/bid_conf.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -533,29 +533,6 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #define DECIMAL_GLOBAL_EXCEPTION_FLAGS_ACCESS_FUNCTIONS 1
 #define BID_HAS_GCC_DECIMAL_INTRINSICS 1
 #endif /* IN_LIBGCC2 */
-
-// We are in libdfp.
-#ifndef BID_BIG_ENDIAN
-#define BID_BIG_ENDIAN __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__
-#endif
-
-#ifndef BID_THREAD
-#if defined (HAVE_CC_TLS) && defined (USE_TLS)
-#define BID_THREAD __thread
-#endif
-#endif
-
-#define _intptr_t_defined
-#define DECIMAL_CALL_BY_REFERENCE 0
-#define DECIMAL_GLOBAL_ROUNDING 1
-#define DECIMAL_GLOBAL_ROUNDING_ACCESS_FUNCTIONS 1
-#define DECIMAL_GLOBAL_EXCEPTION_FLAGS 1
-#define DECIMAL_GLOBAL_EXCEPTION_FLAGS_ACCESS_FUNCTIONS 1
-#define BID_HAS_GCC_DECIMAL_INTRINSICS 1
-extern void __dfp_set_status (int excepts);
-// Use a statement expression (GNU C) to quiet warnings
-#define __set_status_flags(fpsc, status) ({ __dfp_set_status(status); (void)fpsc; })
-// End libdfp options
 
 // Configuration Options
 

--- a/libbid/bid_convert_data.c
+++ b/libbid/bid_convert_data.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_decimal_data.c
+++ b/libbid/bid_decimal_data.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_decimal_globals.c
+++ b/libbid/bid_decimal_globals.c
@@ -86,6 +86,24 @@ __dfp_raise_except (int mask) {
 
   _IDEC_glbflags |= flags;
 }
+
+void
+__dfp_set_status (int excepts) {
+  _IDEC_glbflags |= excepts;
+  if (excepts == INEXACT_EXCEPTION)
+    {
+      fesetexcept (FE_INEXACT);
+    }
+  else
+    {
+      int fexcepts = (excepts & INEXACT_EXCEPTION) ? FE_INEXACT : 0;
+      fexcepts = (excepts & OVERFLOW_EXCEPTION) ? FE_OVERFLOW : 0;
+      fexcepts = (excepts & UNDERFLOW_EXCEPTION) ? FE_UNDERFLOW : 0;
+      fexcepts = (excepts & ZERO_DIVIDE_EXCEPTION) ? FE_DIVBYZERO : 0;
+      fexcepts = (excepts & INVALID_EXCEPTION) ? FE_INVALID: 0;
+      fesetexcept (fexcepts);
+    }
+}
 #endif
 #endif
 

--- a/libbid/bid_decimal_globals.c
+++ b/libbid/bid_decimal_globals.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -85,24 +85,6 @@ __dfp_raise_except (int mask) {
     flags |= INVALID_EXCEPTION;
 
   _IDEC_glbflags |= flags;
-}
-
-void
-__dfp_set_status (int excepts) {
-  _IDEC_glbflags |= excepts;
-  if (excepts == INEXACT_EXCEPTION)
-    {
-      fesetexcept (FE_INEXACT);
-    }
-  else
-    {
-      int fexcepts = (excepts & INEXACT_EXCEPTION) ? FE_INEXACT : 0;
-      fexcepts = (excepts & OVERFLOW_EXCEPTION) ? FE_OVERFLOW : 0;
-      fexcepts = (excepts & UNDERFLOW_EXCEPTION) ? FE_UNDERFLOW : 0;
-      fexcepts = (excepts & ZERO_DIVIDE_EXCEPTION) ? FE_DIVBYZERO : 0;
-      fexcepts = (excepts & INVALID_EXCEPTION) ? FE_INVALID: 0;
-      fesetexcept (fexcepts);
-    }
 }
 #endif
 #endif

--- a/libbid/bid_div_macros.h
+++ b/libbid/bid_div_macros.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_dpd.c
+++ b/libbid/bid_dpd.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_flag_operations.c
+++ b/libbid/bid_flag_operations.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_from_int.c
+++ b/libbid/bid_from_int.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_functions.h
+++ b/libbid/bid_functions.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_gcc_intrinsics.h
+++ b/libbid/bid_gcc_intrinsics.h
@@ -99,16 +99,17 @@ typedef __attribute__ ((aligned(16))) struct
 } UINT128;
 #else	/* if not IN_LIBGCC2 */
 
-#ifndef BID_HAS_XF_MODE
+#if defined(__i386__) || defined (__amd64__)
 #define BID_HAS_XF_MODE 1
+#define LIBGCC2_HAS_XF_MODE 1
+#define __LIBGCC_HAS_XF_MODE__
+#else
+#define BID_HAS_XF_MODE 0
+#define LIBGCC2_HAS_XF_MODE 0
 #endif
 
 #ifndef BID_HAS_TF_MODE
-#if defined __i386__
-#define BID_HAS_TF_MODE 0
-#else
 #define BID_HAS_TF_MODE 1
-#endif
 #endif
 
 #if BID_HAS_HF_MODE
@@ -161,119 +162,119 @@ typedef __attribute__ ((aligned(16))) struct
 #if BID_HAS_GCC_DECIMAL_INTRINSICS
 /* Prototypes for gcc instrinsics  */
 
-extern _Decimal64 __bid_adddd3 (_Decimal64, _Decimal64);
-extern _Decimal64 __bid_subdd3 (_Decimal64, _Decimal64);
-extern _Decimal32 __bid_addsd3 (_Decimal32, _Decimal32);
-extern _Decimal32 __bid_subsd3 (_Decimal32, _Decimal32);
-extern _Decimal128 __bid_addtd3 (_Decimal128, _Decimal128);
-extern _Decimal128 __bid_subtd3 (_Decimal128, _Decimal128);
-extern DFtype __bid_truncdddf (_Decimal64);
-extern DItype __bid_fixdddi (_Decimal64);
-extern _Decimal32 __bid_truncddsd2 (_Decimal64);
-extern SFtype __bid_truncddsf (_Decimal64);
-extern SItype __bid_fixddsi (_Decimal64);
-extern _Decimal128 __bid_extendddtd2 (_Decimal64);
+extern _Decimal64 __bid_adddd3 (_Decimal64, _Decimal64); hidden_proto(__bid_adddd3);
+extern _Decimal64 __bid_subdd3 (_Decimal64, _Decimal64); hidden_proto(__bid_subdd3);
+extern _Decimal32 __bid_addsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_addsd3);
+extern _Decimal32 __bid_subsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_subsd3);
+extern _Decimal128 __bid_addtd3 (_Decimal128, _Decimal128); hidden_proto(__bid_addtd3);
+extern _Decimal128 __bid_subtd3 (_Decimal128, _Decimal128); hidden_proto(__bid_subtd3);
+extern DFtype __bid_truncdddf (_Decimal64); hidden_proto(__bid_truncdddf);
+extern DItype __bid_fixdddi (_Decimal64); hidden_proto(__bid_fixdddi);
+extern _Decimal32 __bid_truncddsd2 (_Decimal64); hidden_proto(__bid_truncddsd2);
+extern SFtype __bid_truncddsf (_Decimal64); hidden_proto(__bid_truncddsf);
+extern SItype __bid_fixddsi (_Decimal64); hidden_proto(__bid_fixddsi);
+extern _Decimal128 __bid_extendddtd2 (_Decimal64); hidden_proto(__bid_extendddtd2);
 #if BID_HAS_TF_MODE
-extern TFtype __bid_extendddtf (_Decimal64);
+extern TFtype __bid_extendddtf (_Decimal64); hidden_proto(__bid_extendddtf);
 #endif
-extern UDItype __bid_fixunsdddi (_Decimal64);
-extern USItype __bid_fixunsddsi (_Decimal64);
+extern UDItype __bid_fixunsdddi (_Decimal64); hidden_proto(__bid_fixunsdddi);
+extern USItype __bid_fixunsddsi (_Decimal64); hidden_proto(__bid_fixunsddsi);
 #if BID_HAS_XF_MODE
-extern XFtype __bid_extendddxf (_Decimal64);
+extern XFtype __bid_extendddxf (_Decimal64); hidden_proto(__bid_extendddxf);
 #endif
-extern _Decimal64 __bid_extenddfdd (DFtype);
-extern _Decimal32 __bid_truncdfsd (DFtype);
-extern _Decimal128 __bid_extenddftd (DFtype);
-extern _Decimal64 __bid_floatdidd (DItype);
-extern _Decimal32 __bid_floatdisd (DItype);
-extern _Decimal128 __bid_floatditd (DItype);
-extern _Decimal64 __bid_divdd3 (_Decimal64, _Decimal64);
-extern _Decimal32 __bid_divsd3 (_Decimal32, _Decimal32);
-extern _Decimal128 __bid_divtd3 (_Decimal128, _Decimal128);
-extern CMPtype __bid_eqdd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_eqsd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_eqtd2 (_Decimal128, _Decimal128);
-extern CMPtype __bid_gedd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_gesd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_getd2 (_Decimal128, _Decimal128);
-extern CMPtype __bid_gtdd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_gtsd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_gttd2 (_Decimal128, _Decimal128);
-extern CMPtype __bid_ledd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_lesd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_letd2 (_Decimal128, _Decimal128);
-extern CMPtype __bid_ltdd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_ltsd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_lttd2 (_Decimal128, _Decimal128);
-extern CMPtype __bid_nedd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_nesd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_netd2 (_Decimal128, _Decimal128);
-extern CMPtype __bid_unorddd2 (_Decimal64, _Decimal64);
-extern CMPtype __bid_unordsd2 (_Decimal32, _Decimal32);
-extern CMPtype __bid_unordtd2 (_Decimal128, _Decimal128);
-extern _Decimal64 __bid_muldd3 (_Decimal64, _Decimal64);
-extern _Decimal32 __bid_mulsd3 (_Decimal32, _Decimal32);
-extern _Decimal128 __bid_multd3 (_Decimal128, _Decimal128);
-extern _Decimal64 __bid_extendsddd2 (_Decimal32);
-extern DFtype __bid_extendsddf (_Decimal32);
-extern DItype __bid_fixsddi (_Decimal32);
-extern SFtype __bid_truncsdsf (_Decimal32);
-extern SItype __bid_fixsdsi (_Decimal32);
-extern _Decimal128 __bid_extendsdtd2 (_Decimal32);
+extern _Decimal64 __bid_extenddfdd (DFtype); hidden_proto(__bid_extenddfdd);
+extern _Decimal32 __bid_truncdfsd (DFtype); hidden_proto(__bid_truncdfsd);
+extern _Decimal128 __bid_extenddftd (DFtype); hidden_proto(__bid_extenddftd);
+extern _Decimal64 __bid_floatdidd (DItype); hidden_proto(__bid_floatdidd);
+extern _Decimal32 __bid_floatdisd (DItype); hidden_proto(__bid_floatdisd);
+extern _Decimal128 __bid_floatditd (DItype); hidden_proto(__bid_floatditd);
+extern _Decimal64 __bid_divdd3 (_Decimal64, _Decimal64); hidden_proto(__bid_divdd3);
+extern _Decimal32 __bid_divsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_divsd3);
+extern _Decimal128 __bid_divtd3 (_Decimal128, _Decimal128); hidden_proto(__bid_divtd3);
+extern CMPtype __bid_eqdd2 (_Decimal64, _Decimal64); hidden_proto(__bid_eqdd2);
+extern CMPtype __bid_eqsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_eqsd2);
+extern CMPtype __bid_eqtd2 (_Decimal128, _Decimal128); hidden_proto(__bid_eqtd2);
+extern CMPtype __bid_gedd2 (_Decimal64, _Decimal64); hidden_proto(__bid_gedd2);
+extern CMPtype __bid_gesd2 (_Decimal32, _Decimal32); hidden_proto(__bid_gesd2);
+extern CMPtype __bid_getd2 (_Decimal128, _Decimal128); hidden_proto(__bid_getd2);
+extern CMPtype __bid_gtdd2 (_Decimal64, _Decimal64); hidden_proto(__bid_gtdd2);
+extern CMPtype __bid_gtsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_gtsd2);
+extern CMPtype __bid_gttd2 (_Decimal128, _Decimal128); hidden_proto(__bid_gttd2);
+extern CMPtype __bid_ledd2 (_Decimal64, _Decimal64); hidden_proto(__bid_ledd2);
+extern CMPtype __bid_lesd2 (_Decimal32, _Decimal32); hidden_proto(__bid_lesd2);
+extern CMPtype __bid_letd2 (_Decimal128, _Decimal128); hidden_proto(__bid_letd2);
+extern CMPtype __bid_ltdd2 (_Decimal64, _Decimal64); hidden_proto(__bid_ltdd2);
+extern CMPtype __bid_ltsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_ltsd2);
+extern CMPtype __bid_lttd2 (_Decimal128, _Decimal128); hidden_proto(__bid_lttd2);
+extern CMPtype __bid_nedd2 (_Decimal64, _Decimal64); hidden_proto(__bid_nedd2);
+extern CMPtype __bid_nesd2 (_Decimal32, _Decimal32); hidden_proto(__bid_nesd2);
+extern CMPtype __bid_netd2 (_Decimal128, _Decimal128); hidden_proto(__bid_netd2);
+extern CMPtype __bid_unorddd2 (_Decimal64, _Decimal64); hidden_proto(__bid_unorddd2);
+extern CMPtype __bid_unordsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_unordsd2);
+extern CMPtype __bid_unordtd2 (_Decimal128, _Decimal128); hidden_proto(__bid_unordtd2);
+extern _Decimal64 __bid_muldd3 (_Decimal64, _Decimal64); hidden_proto(__bid_muldd3);
+extern _Decimal32 __bid_mulsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_mulsd3);
+extern _Decimal128 __bid_multd3 (_Decimal128, _Decimal128); hidden_proto(__bid_multd3);
+extern _Decimal64 __bid_extendsddd2 (_Decimal32); hidden_proto(__bid_extendsddd2);
+extern DFtype __bid_extendsddf (_Decimal32); hidden_proto(__bid_extendsddf);
+extern DItype __bid_fixsddi (_Decimal32); hidden_proto(__bid_fixsddi);
+extern SFtype __bid_truncsdsf (_Decimal32); hidden_proto(__bid_truncsdsf);
+extern SItype __bid_fixsdsi (_Decimal32); hidden_proto(__bid_fixsdsi);
+extern _Decimal128 __bid_extendsdtd2 (_Decimal32); hidden_proto(__bid_extendsdtd2);
 #if BID_HAS_TF_MODE
-extern TFtype __bid_extendsdtf (_Decimal32);
+extern TFtype __bid_extendsdtf (_Decimal32); hidden_proto(__bid_extendsdtf);
 #endif
-extern UDItype __bid_fixunssddi (_Decimal32);
-extern USItype __bid_fixunssdsi (_Decimal32);
+extern UDItype __bid_fixunssddi (_Decimal32); hidden_proto(__bid_fixunssddi);
+extern USItype __bid_fixunssdsi (_Decimal32); hidden_proto(__bid_fixunssdsi);
 #if BID_HAS_XF_MODE
-extern XFtype __bid_extendsdxf (_Decimal32);
+extern XFtype __bid_extendsdxf (_Decimal32); hidden_proto(__bid_extendsdxf);
 #endif
-extern _Decimal64 __bid_extendsfdd (SFtype);
-extern _Decimal32 __bid_extendsfsd (SFtype);
-extern _Decimal128 __bid_extendsftd (SFtype);
-extern _Decimal64 __bid_floatsidd (SItype);
-extern _Decimal32 __bid_floatsisd (SItype);
-extern _Decimal128 __bid_floatsitd (SItype);
-extern _Decimal64 __bid_trunctddd2 (_Decimal128);
-extern DFtype __bid_trunctddf (_Decimal128);
-extern DItype __bid_fixtddi (_Decimal128);
-extern _Decimal32 __bid_trunctdsd2 (_Decimal128);
-extern SFtype __bid_trunctdsf (_Decimal128);
-extern SItype __bid_fixtdsi (_Decimal128);
+extern _Decimal64 __bid_extendsfdd (SFtype); hidden_proto(__bid_extendsfdd);
+extern _Decimal32 __bid_extendsfsd (SFtype); hidden_proto(__bid_extendsfsd);
+extern _Decimal128 __bid_extendsftd (SFtype); hidden_proto(__bid_extendsftd);
+extern _Decimal64 __bid_floatsidd (SItype); hidden_proto(__bid_floatsidd);
+extern _Decimal32 __bid_floatsisd (SItype); hidden_proto(__bid_floatsisd);
+extern _Decimal128 __bid_floatsitd (SItype); hidden_proto(__bid_floatsitd);
+extern _Decimal64 __bid_trunctddd2 (_Decimal128); hidden_proto(__bid_trunctddd2);
+extern DFtype __bid_trunctddf (_Decimal128); hidden_proto(__bid_trunctddf);
+extern DItype __bid_fixtddi (_Decimal128); hidden_proto(__bid_fixtddi);
+extern _Decimal32 __bid_trunctdsd2 (_Decimal128); hidden_proto(__bid_trunctdsd2);
+extern SFtype __bid_trunctdsf (_Decimal128); hidden_proto(__bid_trunctdsf);
+extern SItype __bid_fixtdsi (_Decimal128); hidden_proto(__bid_fixtdsi);
 #if BID_HAS_TF_MODE
-extern TFtype __bid_trunctdtf (_Decimal128);
+extern TFtype __bid_trunctdtf (_Decimal128); hidden_proto(__bid_trunctdtf);
 #endif
-extern UDItype __bid_fixunstddi (_Decimal128);
-extern USItype __bid_fixunstdsi (_Decimal128);
+extern UDItype __bid_fixunstddi (_Decimal128); hidden_proto(__bid_fixunstddi);
+extern USItype __bid_fixunstdsi (_Decimal128); hidden_proto(__bid_fixunstdsi);
 #if BID_HAS_XF_MODE
-extern XFtype __bid_trunctdxf (_Decimal128);
+extern XFtype __bid_trunctdxf (_Decimal128); hidden_proto(__bid_trunctdxf);
 #endif
 #if BID_HAS_TF_MODE
-extern _Decimal64 __bid_trunctfdd (TFtype);
-extern _Decimal32 __bid_trunctfsd (TFtype);
-extern _Decimal128 __bid_extendtftd (TFtype);
+extern _Decimal64 __bid_trunctfdd (TFtype); hidden_proto(__bid_trunctfdd);
+extern _Decimal32 __bid_trunctfsd (TFtype); hidden_proto(__bid_trunctfsd);
+extern _Decimal128 __bid_extendtftd (TFtype); hidden_proto(__bid_extendtftd);
 #endif
-extern _Decimal64 __bid_floatunsdidd (UDItype);
-extern _Decimal32 __bid_floatunsdisd (UDItype);
-extern _Decimal128 __bid_floatunsditd (UDItype);
-extern _Decimal64 __bid_floatunssidd (USItype);
-extern _Decimal32 __bid_floatunssisd (USItype);
-extern _Decimal128 __bid_floatunssitd (USItype);
+extern _Decimal64 __bid_floatunsdidd (UDItype); hidden_proto(__bid_floatunsdidd);
+extern _Decimal32 __bid_floatunsdisd (UDItype); hidden_proto(__bid_floatunsdisd);
+extern _Decimal128 __bid_floatunsditd (UDItype); hidden_proto(__bid_floatunsditd);
+extern _Decimal64 __bid_floatunssidd (USItype); hidden_proto(__bid_floatunssidd);
+extern _Decimal32 __bid_floatunssisd (USItype); hidden_proto(__bid_floatunssisd);
+extern _Decimal128 __bid_floatunssitd (USItype); hidden_proto(__bid_floatunssitd);
 #if BID_HAS_XF_MODE
-extern _Decimal64 __bid_truncxfdd (XFtype);
-extern _Decimal32 __bid_truncxfsd (XFtype);
-extern _Decimal128 __bid_extendxftd (XFtype);
+extern _Decimal64 __bid_truncxfdd (XFtype); hidden_proto(__bid_truncxfdd);
+extern _Decimal32 __bid_truncxfsd (XFtype); hidden_proto(__bid_truncxfsd);
+extern _Decimal128 __bid_extendxftd (XFtype); hidden_proto(__bid_extendxftd);
 #endif
 extern int isinfd32 (_Decimal32);
 extern int isinfd64 (_Decimal64);
 extern int isinfd128 (_Decimal128);
 #if BID_HAS_HF_MODE
-extern _Decimal32 __bid_extendhfsd (HFtype);
-extern _Decimal64 __bid_extendhfdd (HFtype);
-extern _Decimal128 __bid_extendhftd (HFtype);
-extern HFtype __bid_truncsdhf (_Decimal32);
-extern HFtype __bid_truncddhf (_Decimal64);
-extern HFtype __bid_trunctdhf (_Decimal128);
+extern _Decimal32 __bid_extendhfsd (HFtype); hidden_proto(__bid_extendhfsd);
+extern _Decimal64 __bid_extendhfdd (HFtype); hidden_proto(__bid_extendhfdd);
+extern _Decimal128 __bid_extendhftd (HFtype); hidden_proto(__bid_extendhftd);
+extern HFtype __bid_truncsdhf (_Decimal32); hidden_proto(__bid_truncsdhf);
+extern HFtype __bid_truncddhf (_Decimal64); hidden_proto(__bid_truncddhf);
+extern HFtype __bid_trunctdhf (_Decimal128); hidden_proto(__bid_trunctdhf);
 #endif
 #endif  /* BID_HAS_GCC_DECIMAL_INTRINSICS */
 

--- a/libbid/bid_gcc_intrinsics.h
+++ b/libbid/bid_gcc_intrinsics.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -31,7 +31,11 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #include "tm.h"
 #include "libgcc_tm.h"
 
-#include "libdfp-symbols.h"
+#ifdef __LIBGCC_HAS_HF_MODE__
+#define LIBGCC2_HAS_HF_MODE 1
+#else
+#define LIBGCC2_HAS_HF_MODE 0
+#endif
 
 #ifdef __LIBGCC_HAS_XF_MODE__
 #define LIBGCC2_HAS_XF_MODE 1
@@ -45,6 +49,10 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #define LIBGCC2_HAS_TF_MODE 0
 #endif
 
+#ifndef BID_HAS_HF_MODE
+#define BID_HAS_HF_MODE LIBGCC2_HAS_HF_MODE
+#endif
+
 #ifndef BID_HAS_XF_MODE
 #define BID_HAS_XF_MODE LIBGCC2_HAS_XF_MODE
 #endif
@@ -55,6 +63,9 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 
 /* Some handy typedefs.  */
 
+#if LIBGCC2_HAS_HF_MODE
+typedef float HFtype __attribute__ ((mode (HF)));
+#endif /* LIBGCC2_HAS_HF_MODE */
 typedef float SFtype __attribute__ ((mode (SF)));
 typedef float DFtype __attribute__ ((mode (DF)));
 #if LIBGCC2_HAS_XF_MODE
@@ -93,7 +104,17 @@ typedef __attribute__ ((aligned(16))) struct
 #endif
 
 #ifndef BID_HAS_TF_MODE
+#if defined __i386__
+#define BID_HAS_TF_MODE 0
+#else
 #define BID_HAS_TF_MODE 1
+#endif
+#endif
+
+#if BID_HAS_HF_MODE
+#ifndef HFtype
+#define HFtype _Float16
+#endif
 #endif
 
 #ifndef SFtype
@@ -108,8 +129,7 @@ typedef __attribute__ ((aligned(16))) struct
 #ifndef XFtype
 #define XFtype long double
 #endif
-
-#endif   /* IN_LIBGCC2 */
+#endif
 
 #if BID_HAS_TF_MODE
 #ifndef TFtype
@@ -141,112 +161,120 @@ typedef __attribute__ ((aligned(16))) struct
 #if BID_HAS_GCC_DECIMAL_INTRINSICS
 /* Prototypes for gcc instrinsics  */
 
-extern _Decimal64 __bid_adddd3 (_Decimal64, _Decimal64); hidden_proto(__bid_adddd3);
-extern _Decimal64 __bid_subdd3 (_Decimal64, _Decimal64); hidden_proto(__bid_subdd3);
-extern _Decimal32 __bid_addsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_addsd3);
-extern _Decimal32 __bid_subsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_subsd3);
-extern _Decimal128 __bid_addtd3 (_Decimal128, _Decimal128); hidden_proto(__bid_addtd3);
-extern _Decimal128 __bid_subtd3 (_Decimal128, _Decimal128); hidden_proto(__bid_subtd3);
-extern DFtype __bid_truncdddf (_Decimal64); hidden_proto(__bid_truncdddf);
-extern DItype __bid_fixdddi (_Decimal64); hidden_proto(__bid_fixdddi);
-extern _Decimal32 __bid_truncddsd2 (_Decimal64); hidden_proto(__bid_truncddsd2);
-extern SFtype __bid_truncddsf (_Decimal64); hidden_proto(__bid_truncddsf);
-extern SItype __bid_fixddsi (_Decimal64); hidden_proto(__bid_fixddsi);
-extern _Decimal128 __bid_extendddtd2 (_Decimal64); hidden_proto(__bid_extendddtd2);
+extern _Decimal64 __bid_adddd3 (_Decimal64, _Decimal64);
+extern _Decimal64 __bid_subdd3 (_Decimal64, _Decimal64);
+extern _Decimal32 __bid_addsd3 (_Decimal32, _Decimal32);
+extern _Decimal32 __bid_subsd3 (_Decimal32, _Decimal32);
+extern _Decimal128 __bid_addtd3 (_Decimal128, _Decimal128);
+extern _Decimal128 __bid_subtd3 (_Decimal128, _Decimal128);
+extern DFtype __bid_truncdddf (_Decimal64);
+extern DItype __bid_fixdddi (_Decimal64);
+extern _Decimal32 __bid_truncddsd2 (_Decimal64);
+extern SFtype __bid_truncddsf (_Decimal64);
+extern SItype __bid_fixddsi (_Decimal64);
+extern _Decimal128 __bid_extendddtd2 (_Decimal64);
 #if BID_HAS_TF_MODE
-extern TFtype __bid_extendddtf (_Decimal64); hidden_proto(__bid_extendddtf);
+extern TFtype __bid_extendddtf (_Decimal64);
 #endif
-extern UDItype __bid_fixunsdddi (_Decimal64); hidden_proto(__bid_fixunsdddi);
-extern USItype __bid_fixunsddsi (_Decimal64); hidden_proto(__bid_fixunsddsi);
+extern UDItype __bid_fixunsdddi (_Decimal64);
+extern USItype __bid_fixunsddsi (_Decimal64);
 #if BID_HAS_XF_MODE
-extern XFtype __bid_extendddxf (_Decimal64); hidden_proto(__bid_extendddxf);
+extern XFtype __bid_extendddxf (_Decimal64);
 #endif
-extern _Decimal64 __bid_extenddfdd (DFtype); hidden_proto(__bid_extenddfdd);
-extern _Decimal32 __bid_truncdfsd (DFtype); hidden_proto(__bid_truncdfsd);
-extern _Decimal128 __bid_extenddftd (DFtype); hidden_proto(__bid_extenddftd);
-extern _Decimal64 __bid_floatdidd (DItype); hidden_proto(__bid_floatdidd);
-extern _Decimal32 __bid_floatdisd (DItype); hidden_proto(__bid_floatdisd);
-extern _Decimal128 __bid_floatditd (DItype); hidden_proto(__bid_floatditd);
-extern _Decimal64 __bid_divdd3 (_Decimal64, _Decimal64); hidden_proto(__bid_divdd3);
-extern _Decimal32 __bid_divsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_divsd3);
-extern _Decimal128 __bid_divtd3 (_Decimal128, _Decimal128); hidden_proto(__bid_divtd3);
-extern CMPtype __bid_eqdd2 (_Decimal64, _Decimal64); hidden_proto(__bid_eqdd2);
-extern CMPtype __bid_eqsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_eqsd2);
-extern CMPtype __bid_eqtd2 (_Decimal128, _Decimal128); hidden_proto(__bid_eqtd2);
-extern CMPtype __bid_gedd2 (_Decimal64, _Decimal64); hidden_proto(__bid_gedd2);
-extern CMPtype __bid_gesd2 (_Decimal32, _Decimal32); hidden_proto(__bid_gesd2);
-extern CMPtype __bid_getd2 (_Decimal128, _Decimal128); hidden_proto(__bid_getd2);
-extern CMPtype __bid_gtdd2 (_Decimal64, _Decimal64); hidden_proto(__bid_gtdd2);
-extern CMPtype __bid_gtsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_gtsd2);
-extern CMPtype __bid_gttd2 (_Decimal128, _Decimal128); hidden_proto(__bid_gttd2);
-extern CMPtype __bid_ledd2 (_Decimal64, _Decimal64); hidden_proto(__bid_ledd2);
-extern CMPtype __bid_lesd2 (_Decimal32, _Decimal32); hidden_proto(__bid_lesd2);
-extern CMPtype __bid_letd2 (_Decimal128, _Decimal128); hidden_proto(__bid_letd2);
-extern CMPtype __bid_ltdd2 (_Decimal64, _Decimal64); hidden_proto(__bid_ltdd2);
-extern CMPtype __bid_ltsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_ltsd2);
-extern CMPtype __bid_lttd2 (_Decimal128, _Decimal128); hidden_proto(__bid_lttd2);
-extern CMPtype __bid_nedd2 (_Decimal64, _Decimal64); hidden_proto(__bid_nedd2);
-extern CMPtype __bid_nesd2 (_Decimal32, _Decimal32); hidden_proto(__bid_nesd2);
-extern CMPtype __bid_netd2 (_Decimal128, _Decimal128); hidden_proto(__bid_netd2);
-extern CMPtype __bid_unorddd2 (_Decimal64, _Decimal64); hidden_proto(__bid_unorddd2);
-extern CMPtype __bid_unordsd2 (_Decimal32, _Decimal32); hidden_proto(__bid_unordsd2);
-extern CMPtype __bid_unordtd2 (_Decimal128, _Decimal128); hidden_proto(__bid_unordtd2);
-extern _Decimal64 __bid_muldd3 (_Decimal64, _Decimal64); hidden_proto(__bid_muldd3);
-extern _Decimal32 __bid_mulsd3 (_Decimal32, _Decimal32); hidden_proto(__bid_mulsd3);
-extern _Decimal128 __bid_multd3 (_Decimal128, _Decimal128); hidden_proto(__bid_multd3);
-extern _Decimal64 __bid_extendsddd2 (_Decimal32); hidden_proto(__bid_extendsddd2);
-extern DFtype __bid_extendsddf (_Decimal32); hidden_proto(__bid_extendsddf);
-extern DItype __bid_fixsddi (_Decimal32); hidden_proto(__bid_fixsddi);
-extern SFtype __bid_truncsdsf (_Decimal32); hidden_proto(__bid_truncsdsf);
-extern SItype __bid_fixsdsi (_Decimal32); hidden_proto(__bid_fixsdsi);
-extern _Decimal128 __bid_extendsdtd2 (_Decimal32); hidden_proto(__bid_extendsdtd2);
+extern _Decimal64 __bid_extenddfdd (DFtype);
+extern _Decimal32 __bid_truncdfsd (DFtype);
+extern _Decimal128 __bid_extenddftd (DFtype);
+extern _Decimal64 __bid_floatdidd (DItype);
+extern _Decimal32 __bid_floatdisd (DItype);
+extern _Decimal128 __bid_floatditd (DItype);
+extern _Decimal64 __bid_divdd3 (_Decimal64, _Decimal64);
+extern _Decimal32 __bid_divsd3 (_Decimal32, _Decimal32);
+extern _Decimal128 __bid_divtd3 (_Decimal128, _Decimal128);
+extern CMPtype __bid_eqdd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_eqsd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_eqtd2 (_Decimal128, _Decimal128);
+extern CMPtype __bid_gedd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_gesd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_getd2 (_Decimal128, _Decimal128);
+extern CMPtype __bid_gtdd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_gtsd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_gttd2 (_Decimal128, _Decimal128);
+extern CMPtype __bid_ledd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_lesd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_letd2 (_Decimal128, _Decimal128);
+extern CMPtype __bid_ltdd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_ltsd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_lttd2 (_Decimal128, _Decimal128);
+extern CMPtype __bid_nedd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_nesd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_netd2 (_Decimal128, _Decimal128);
+extern CMPtype __bid_unorddd2 (_Decimal64, _Decimal64);
+extern CMPtype __bid_unordsd2 (_Decimal32, _Decimal32);
+extern CMPtype __bid_unordtd2 (_Decimal128, _Decimal128);
+extern _Decimal64 __bid_muldd3 (_Decimal64, _Decimal64);
+extern _Decimal32 __bid_mulsd3 (_Decimal32, _Decimal32);
+extern _Decimal128 __bid_multd3 (_Decimal128, _Decimal128);
+extern _Decimal64 __bid_extendsddd2 (_Decimal32);
+extern DFtype __bid_extendsddf (_Decimal32);
+extern DItype __bid_fixsddi (_Decimal32);
+extern SFtype __bid_truncsdsf (_Decimal32);
+extern SItype __bid_fixsdsi (_Decimal32);
+extern _Decimal128 __bid_extendsdtd2 (_Decimal32);
 #if BID_HAS_TF_MODE
-extern TFtype __bid_extendsdtf (_Decimal32); hidden_proto(__bid_extendsdtf);
+extern TFtype __bid_extendsdtf (_Decimal32);
 #endif
-extern UDItype __bid_fixunssddi (_Decimal32); hidden_proto(__bid_fixunssddi);
-extern USItype __bid_fixunssdsi (_Decimal32); hidden_proto(__bid_fixunssdsi);
+extern UDItype __bid_fixunssddi (_Decimal32);
+extern USItype __bid_fixunssdsi (_Decimal32);
 #if BID_HAS_XF_MODE
-extern XFtype __bid_extendsdxf (_Decimal32); hidden_proto(__bid_extendsdxf);
+extern XFtype __bid_extendsdxf (_Decimal32);
 #endif
-extern _Decimal64 __bid_extendsfdd (SFtype); hidden_proto(__bid_extendsfdd);
-extern _Decimal32 __bid_extendsfsd (SFtype); hidden_proto(__bid_extendsfsd);
-extern _Decimal128 __bid_extendsftd (SFtype); hidden_proto(__bid_extendsftd);
-extern _Decimal64 __bid_floatsidd (SItype); hidden_proto(__bid_floatsidd);
-extern _Decimal32 __bid_floatsisd (SItype); hidden_proto(__bid_floatsisd);
-extern _Decimal128 __bid_floatsitd (SItype); hidden_proto(__bid_floatsitd);
-extern _Decimal64 __bid_trunctddd2 (_Decimal128); hidden_proto(__bid_trunctddd2);
-extern DFtype __bid_trunctddf (_Decimal128); hidden_proto(__bid_trunctddf);
-extern DItype __bid_fixtddi (_Decimal128); hidden_proto(__bid_fixtddi);
-extern _Decimal32 __bid_trunctdsd2 (_Decimal128); hidden_proto(__bid_trunctdsd2);
-extern SFtype __bid_trunctdsf (_Decimal128); hidden_proto(__bid_trunctdsf);
-extern SItype __bid_fixtdsi (_Decimal128); hidden_proto(__bid_fixtdsi);
+extern _Decimal64 __bid_extendsfdd (SFtype);
+extern _Decimal32 __bid_extendsfsd (SFtype);
+extern _Decimal128 __bid_extendsftd (SFtype);
+extern _Decimal64 __bid_floatsidd (SItype);
+extern _Decimal32 __bid_floatsisd (SItype);
+extern _Decimal128 __bid_floatsitd (SItype);
+extern _Decimal64 __bid_trunctddd2 (_Decimal128);
+extern DFtype __bid_trunctddf (_Decimal128);
+extern DItype __bid_fixtddi (_Decimal128);
+extern _Decimal32 __bid_trunctdsd2 (_Decimal128);
+extern SFtype __bid_trunctdsf (_Decimal128);
+extern SItype __bid_fixtdsi (_Decimal128);
 #if BID_HAS_TF_MODE
-extern TFtype __bid_trunctdtf (_Decimal128); hidden_proto(__bid_trunctdtf);
+extern TFtype __bid_trunctdtf (_Decimal128);
 #endif
-extern UDItype __bid_fixunstddi (_Decimal128); hidden_proto(__bid_fixunstddi);
-extern USItype __bid_fixunstdsi (_Decimal128); hidden_proto(__bid_fixunstdsi);
+extern UDItype __bid_fixunstddi (_Decimal128);
+extern USItype __bid_fixunstdsi (_Decimal128);
 #if BID_HAS_XF_MODE
-extern XFtype __bid_trunctdxf (_Decimal128); hidden_proto(__bid_trunctdxf);
+extern XFtype __bid_trunctdxf (_Decimal128);
 #endif
 #if BID_HAS_TF_MODE
-extern _Decimal64 __bid_trunctfdd (TFtype); hidden_proto(__bid_trunctfdd);
-extern _Decimal32 __bid_trunctfsd (TFtype); hidden_proto(__bid_trunctfsd);
-extern _Decimal128 __bid_extendtftd (TFtype); hidden_proto(__bid_extendtftd);
+extern _Decimal64 __bid_trunctfdd (TFtype);
+extern _Decimal32 __bid_trunctfsd (TFtype);
+extern _Decimal128 __bid_extendtftd (TFtype);
 #endif
-extern _Decimal64 __bid_floatunsdidd (UDItype); hidden_proto(__bid_floatunsdidd);
-extern _Decimal32 __bid_floatunsdisd (UDItype); hidden_proto(__bid_floatunsdisd);
-extern _Decimal128 __bid_floatunsditd (UDItype); hidden_proto(__bid_floatunsditd);
-extern _Decimal64 __bid_floatunssidd (USItype); hidden_proto(__bid_floatunssidd);
-extern _Decimal32 __bid_floatunssisd (USItype); hidden_proto(__bid_floatunssisd);
-extern _Decimal128 __bid_floatunssitd (USItype); hidden_proto(__bid_floatunssitd);
+extern _Decimal64 __bid_floatunsdidd (UDItype);
+extern _Decimal32 __bid_floatunsdisd (UDItype);
+extern _Decimal128 __bid_floatunsditd (UDItype);
+extern _Decimal64 __bid_floatunssidd (USItype);
+extern _Decimal32 __bid_floatunssisd (USItype);
+extern _Decimal128 __bid_floatunssitd (USItype);
 #if BID_HAS_XF_MODE
-extern _Decimal64 __bid_truncxfdd (XFtype); hidden_proto(__bid_truncxfdd);
-extern _Decimal32 __bid_truncxfsd (XFtype); hidden_proto(__bid_truncxfsd);
-extern _Decimal128 __bid_extendxftd (XFtype); hidden_proto(__bid_extendxftd);
+extern _Decimal64 __bid_truncxfdd (XFtype);
+extern _Decimal32 __bid_truncxfsd (XFtype);
+extern _Decimal128 __bid_extendxftd (XFtype);
 #endif
 extern int isinfd32 (_Decimal32);
 extern int isinfd64 (_Decimal64);
 extern int isinfd128 (_Decimal128);
+#if BID_HAS_HF_MODE
+extern _Decimal32 __bid_extendhfsd (HFtype);
+extern _Decimal64 __bid_extendhfdd (HFtype);
+extern _Decimal128 __bid_extendhftd (HFtype);
+extern HFtype __bid_truncsdhf (_Decimal32);
+extern HFtype __bid_truncddhf (_Decimal64);
+extern HFtype __bid_trunctdhf (_Decimal128);
+#endif
 #endif  /* BID_HAS_GCC_DECIMAL_INTRINSICS */
 
 extern void __dfp_set_round (int);

--- a/libbid/bid_inline_add.h
+++ b/libbid/bid_inline_add.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_internal.h
+++ b/libbid/bid_internal.h
@@ -780,7 +780,9 @@ extern UINT128 round_const_table_128[][36];
 //////////////////////////////////////////////
 //  Status Flag Handling
 /////////////////////////////////////////////
+#ifndef __set_status_flags
 #define __set_status_flags(fpsc, status)  *(fpsc) |= status
+#endif
 #define is_inexact(fpsc)  ((*(fpsc))&INEXACT_EXCEPTION)
 
 __BID_INLINE__ UINT64

--- a/libbid/bid_internal.h
+++ b/libbid/bid_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -780,9 +780,7 @@ extern UINT128 round_const_table_128[][36];
 //////////////////////////////////////////////
 //  Status Flag Handling
 /////////////////////////////////////////////
-#ifndef __set_status_flags
 #define __set_status_flags(fpsc, status)  *(fpsc) |= status
-#endif
 #define is_inexact(fpsc)  ((*(fpsc))&INEXACT_EXCEPTION)
 
 __BID_INLINE__ UINT64

--- a/libbid/bid_round.c
+++ b/libbid/bid_round.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/libbid/bid_sqrt_macros.h
+++ b/libbid/bid_sqrt_macros.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Free Software Foundation, Inc.
+/* Copyright (C) 2007-2022 Free Software Foundation, Inc.
 
 This file is part of GCC.
 


### PR DESCRIPTION
I did a bulk import of all the files from gcc, then refreshed the libdfp patches in a second branch.

This might cause some minor irritation if someone ever wants to bisect the bid code (sorry), but this might make it easier to resync with gcc.