### PR TITLE
Update the FSF address

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -66,7 +66,7 @@ the GNU Lesser General Public License version 2.1 for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License version 2.1 along with the Decimal Floating Point C Library;
-if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-Suite 330, Boston, MA 02111-1307 USA.
+if not, write to the Free Software Foundation, Inc., 51 Franklin
+Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 Please see libdfp/COPYING.txt for more information.

--- a/base-math/Makefile
+++ b/base-math/Makefile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License version 2.1 along with the Decimal Floating Point C Library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307 USA.
+# if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/adddd3.c
+++ b/base-math/adddd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/addsd3.c
+++ b/base-math/addsd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/addtd3.c
+++ b/base-math/addtd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/divdd3.c
+++ b/base-math/divdd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/divsd3.c
+++ b/base-math/divsd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/divtd3.c
+++ b/base-math/divtd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/eqdd2.c
+++ b/base-math/eqdd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/eqsd2.c
+++ b/base-math/eqsd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/eqtd2.c
+++ b/base-math/eqtd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendddtd2.c
+++ b/base-math/extendddtd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendddtf.c
+++ b/base-math/extendddtf.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extenddfdd.c
+++ b/base-math/extenddfdd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extenddftd.c
+++ b/base-math/extenddftd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsddd2.c
+++ b/base-math/extendsddd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsddf.c
+++ b/base-math/extendsddf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsdtd2.c
+++ b/base-math/extendsdtd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsdtf.c
+++ b/base-math/extendsdtf.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsfdd.c
+++ b/base-math/extendsfdd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsfsd.c
+++ b/base-math/extendsfsd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendsftd.c
+++ b/base-math/extendsftd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/extendtftd.c
+++ b/base-math/extendtftd.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixdddi.c
+++ b/base-math/fixdddi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixddsi.c
+++ b/base-math/fixddsi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixddti.c
+++ b/base-math/fixddti.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixsddi.c
+++ b/base-math/fixsddi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixsdsi.c
+++ b/base-math/fixsdsi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixsdti.c
+++ b/base-math/fixsdti.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixtddi.c
+++ b/base-math/fixtddi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixtdsi.c
+++ b/base-math/fixtdsi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixtdti.c
+++ b/base-math/fixtdti.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunsdddi.c
+++ b/base-math/fixunsdddi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunsddsi.c
+++ b/base-math/fixunsddsi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunsddti.c
+++ b/base-math/fixunsddti.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunssddi.c
+++ b/base-math/fixunssddi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunssdsi.c
+++ b/base-math/fixunssdsi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunssdti.c
+++ b/base-math/fixunssdti.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunstddi.c
+++ b/base-math/fixunstddi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunstdsi.c
+++ b/base-math/fixunstdsi.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/fixunstdti.c
+++ b/base-math/fixunstdti.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/floatdidd.c
+++ b/base-math/floatdidd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatdisd.c
+++ b/base-math/floatdisd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatditd.c
+++ b/base-math/floatditd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatsidd.c
+++ b/base-math/floatsidd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatsisd.c
+++ b/base-math/floatsisd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatsitd.c
+++ b/base-math/floatsitd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floattidd.c
+++ b/base-math/floattidd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/floattisd.c
+++ b/base-math/floattisd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/floattitd.c
+++ b/base-math/floattitd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunsdidd.c
+++ b/base-math/floatunsdidd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunsdisd.c
+++ b/base-math/floatunsdisd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunsditd.c
+++ b/base-math/floatunsditd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunssidd.c
+++ b/base-math/floatunssidd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunssisd.c
+++ b/base-math/floatunssisd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunssitd.c
+++ b/base-math/floatunssitd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunstidd.c
+++ b/base-math/floatunstidd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunstisd.c
+++ b/base-math/floatunstisd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/floatunstitd.c
+++ b/base-math/floatunstitd.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/base-math/gedd2.c
+++ b/base-math/gedd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/gesd2.c
+++ b/base-math/gesd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/getd2.c
+++ b/base-math/getd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/gtdd2.c
+++ b/base-math/gtdd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/gtsd2.c
+++ b/base-math/gtsd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/gttd2.c
+++ b/base-math/gttd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/ledd2.c
+++ b/base-math/ledd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/lesd2.c
+++ b/base-math/lesd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/letd2.c
+++ b/base-math/letd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/ltdd2.c
+++ b/base-math/ltdd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/ltsd2.c
+++ b/base-math/ltsd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/lttd2.c
+++ b/base-math/lttd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/muldd3.c
+++ b/base-math/muldd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/mulsd3.c
+++ b/base-math/mulsd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/multd3.c
+++ b/base-math/multd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/nedd2.c
+++ b/base-math/nedd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/nesd2.c
+++ b/base-math/nesd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/netd2.c
+++ b/base-math/netd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/subdd3.c
+++ b/base-math/subdd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/subsd3.c
+++ b/base-math/subsd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/subtd3.c
+++ b/base-math/subtd3.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/truncdddf.c
+++ b/base-math/truncdddf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/truncddsd2.c
+++ b/base-math/truncddsd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/truncddsf.c
+++ b/base-math/truncddsf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/truncdfsd.c
+++ b/base-math/truncdfsd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/truncsdsf.c
+++ b/base-math/truncsdsf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctddd2.c
+++ b/base-math/trunctddd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctddf.c
+++ b/base-math/trunctddf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctdsd2.c
+++ b/base-math/trunctdsd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctdsf.c
+++ b/base-math/trunctdsf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctdtf.c
+++ b/base-math/trunctdtf.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctfdd.c
+++ b/base-math/trunctfdd.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/trunctfsd.c
+++ b/base-math/trunctfsd.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/unorddd2.c
+++ b/base-math/unorddd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/unordsd2.c
+++ b/base-math/unordsd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/base-math/unordtd2.c
+++ b/base-math/unordtd2.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/decNumberMath/Makefile
+++ b/decNumberMath/Makefile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License version 2.1 along with the Decimal Floating Point C Library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307 USA.
+# if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please see libdfp/COPYING.txt for more information.  */
 

--- a/decNumberMath/decNumberMath.c
+++ b/decNumberMath/decNumberMath.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/decNumberMath/decNumberMath.h
+++ b/decNumberMath/decNumberMath.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/bits/dfp_dmathcalls.h
+++ b/dfp/bits/dfp_dmathcalls.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/decimal/decimal
+++ b/dfp/decimal/decimal
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/fenv.h
+++ b/dfp/fenv.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/float.h
+++ b/dfp/float.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/math.h
+++ b/dfp/math.h
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/stdlib.h
+++ b/dfp/stdlib.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/dfp/wchar.h
+++ b/dfp/wchar.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/Makefile
+++ b/ieee754r/Makefile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License version 2.1 along with the Decimal Floating Point C Library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307 USA.
+# if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/acosd128.c
+++ b/ieee754r/acosd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/acosd32.c
+++ b/ieee754r/acosd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/acosd64.c
+++ b/ieee754r/acosd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/acoshd128.c
+++ b/ieee754r/acoshd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/acoshd32.c
+++ b/ieee754r/acoshd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/acoshd64.c
+++ b/ieee754r/acoshd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/asind128.c
+++ b/ieee754r/asind128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/asind32.c
+++ b/ieee754r/asind32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/asind64.c
+++ b/ieee754r/asind64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/asinhd128.c
+++ b/ieee754r/asinhd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/asinhd32.c
+++ b/ieee754r/asinhd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/asinhd64.c
+++ b/ieee754r/asinhd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atan2d128.c
+++ b/ieee754r/atan2d128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atan2d32.c
+++ b/ieee754r/atan2d32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atan2d64.c
+++ b/ieee754r/atan2d64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atand128.c
+++ b/ieee754r/atand128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atand32.c
+++ b/ieee754r/atand32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atand64.c
+++ b/ieee754r/atand64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atanhd128.c
+++ b/ieee754r/atanhd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atanhd32.c
+++ b/ieee754r/atanhd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/atanhd64.c
+++ b/ieee754r/atanhd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/cbrtd128.c
+++ b/ieee754r/cbrtd128.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/cbrtd32.c
+++ b/ieee754r/cbrtd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/cbrtd64.c
+++ b/ieee754r/cbrtd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ceild128.c
+++ b/ieee754r/ceild128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ceild32.c
+++ b/ieee754r/ceild32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ceild64.c
+++ b/ieee754r/ceild64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/copysignd128.c
+++ b/ieee754r/copysignd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/copysignd32.c
+++ b/ieee754r/copysignd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/copysignd64.c
+++ b/ieee754r/copysignd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/cosd128.c
+++ b/ieee754r/cosd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/cosd32.c
+++ b/ieee754r/cosd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/cosd64.c
+++ b/ieee754r/cosd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/coshd128.c
+++ b/ieee754r/coshd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/coshd32.c
+++ b/ieee754r/coshd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/coshd64.c
+++ b/ieee754r/coshd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ddlogtbls.h
+++ b/ieee754r/ddlogtbls.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/ieee754r/decexptables.c
+++ b/ieee754r/decexptables.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.
 

--- a/ieee754r/declntables.c
+++ b/ieee754r/declntables.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.
 */

--- a/ieee754r/erfd128.c
+++ b/ieee754r/erfd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/erfd32.c
+++ b/ieee754r/erfd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/erfd64.c
+++ b/ieee754r/erfd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/exp2d128.c
+++ b/ieee754r/exp2d128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/exp2d32.c
+++ b/ieee754r/exp2d32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/exp2d64.c
+++ b/ieee754r/exp2d64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/expd128.c
+++ b/ieee754r/expd128.c
@@ -23,8 +23,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/expd32.c
+++ b/ieee754r/expd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/expd64.c
+++ b/ieee754r/expd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/expm1d128.c
+++ b/ieee754r/expm1d128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/expm1d32.c
+++ b/ieee754r/expm1d32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/expm1d64.c
+++ b/ieee754r/expm1d64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fabsd128.c
+++ b/ieee754r/fabsd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fabsd32.c
+++ b/ieee754r/fabsd32.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fabsd64.c
+++ b/ieee754r/fabsd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fdimd128.c
+++ b/ieee754r/fdimd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fdimd32.c
+++ b/ieee754r/fdimd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fdimd64.c
+++ b/ieee754r/fdimd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/floord128.c
+++ b/ieee754r/floord128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/floord32.c
+++ b/ieee754r/floord32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/floord64.c
+++ b/ieee754r/floord64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmad128.c
+++ b/ieee754r/fmad128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmad32.c
+++ b/ieee754r/fmad32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmad64.c
+++ b/ieee754r/fmad64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmaxd128.c
+++ b/ieee754r/fmaxd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmaxd32.c
+++ b/ieee754r/fmaxd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmaxd64.c
+++ b/ieee754r/fmaxd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmaxmagd128.c
+++ b/ieee754r/fmaxmagd128.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmaxmagd32.c
+++ b/ieee754r/fmaxmagd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmaxmagd64.c
+++ b/ieee754r/fmaxmagd64.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmind128.c
+++ b/ieee754r/fmind128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmind32.c
+++ b/ieee754r/fmind32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmind64.c
+++ b/ieee754r/fmind64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fminmagd128.c
+++ b/ieee754r/fminmagd128.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fminmagd32.c
+++ b/ieee754r/fminmagd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fminmagd64.c
+++ b/ieee754r/fminmagd64.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmodd128.c
+++ b/ieee754r/fmodd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmodd32.c
+++ b/ieee754r/fmodd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fmodd64.c
+++ b/ieee754r/fmodd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fpclassifyd128.c
+++ b/ieee754r/fpclassifyd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fpclassifyd32.c
+++ b/ieee754r/fpclassifyd32.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/fpclassifyd64.c
+++ b/ieee754r/fpclassifyd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/frexpd128.c
+++ b/ieee754r/frexpd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/frexpd32.c
+++ b/ieee754r/frexpd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/frexpd64.c
+++ b/ieee754r/frexpd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/hypotd128.c
+++ b/ieee754r/hypotd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/hypotd32.c
+++ b/ieee754r/hypotd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/hypotd64.c
+++ b/ieee754r/hypotd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ilogbd128.c
+++ b/ieee754r/ilogbd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ilogbd32.c
+++ b/ieee754r/ilogbd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ilogbd64.c
+++ b/ieee754r/ilogbd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isfinited128.c
+++ b/ieee754r/isfinited128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isfinited32.c
+++ b/ieee754r/isfinited32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isfinited64.c
+++ b/ieee754r/isfinited64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isgreaterd128.c
+++ b/ieee754r/isgreaterd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isgreaterd32.c
+++ b/ieee754r/isgreaterd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isgreaterd64.c
+++ b/ieee754r/isgreaterd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isgreaterequald128.c
+++ b/ieee754r/isgreaterequald128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isgreaterequald32.c
+++ b/ieee754r/isgreaterequald32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isgreaterequald64.c
+++ b/ieee754r/isgreaterequald64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isinfd128.c
+++ b/ieee754r/isinfd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isinfd32.c
+++ b/ieee754r/isinfd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isinfd64.c
+++ b/ieee754r/isinfd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessd128.c
+++ b/ieee754r/islessd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessd32.c
+++ b/ieee754r/islessd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessd64.c
+++ b/ieee754r/islessd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessequald128.c
+++ b/ieee754r/islessequald128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessequald32.c
+++ b/ieee754r/islessequald32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessequald64.c
+++ b/ieee754r/islessequald64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessgreaterd128.c
+++ b/ieee754r/islessgreaterd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessgreaterd32.c
+++ b/ieee754r/islessgreaterd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/islessgreaterd64.c
+++ b/ieee754r/islessgreaterd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isnand128.c
+++ b/ieee754r/isnand128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isnand32.c
+++ b/ieee754r/isnand32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isnand64.c
+++ b/ieee754r/isnand64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isnormald128.c
+++ b/ieee754r/isnormald128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isnormald32.c
+++ b/ieee754r/isnormald32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isnormald64.c
+++ b/ieee754r/isnormald64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/issignalingd128.c
+++ b/ieee754r/issignalingd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/issignalingd32.c
+++ b/ieee754r/issignalingd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/issignalingd64.c
+++ b/ieee754r/issignalingd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isunorderedd128.c
+++ b/ieee754r/isunorderedd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isunorderedd32.c
+++ b/ieee754r/isunorderedd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/isunorderedd64.c
+++ b/ieee754r/isunorderedd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ldexpd128.c
+++ b/ieee754r/ldexpd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ldexpd32.c
+++ b/ieee754r/ldexpd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/ldexpd64.c
+++ b/ieee754r/ldexpd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lgammad128.c
+++ b/ieee754r/lgammad128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lgammad32.c
+++ b/ieee754r/lgammad32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lgammad64.c
+++ b/ieee754r/lgammad64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llogbd128.c
+++ b/ieee754r/llogbd128.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llogbd32.c
+++ b/ieee754r/llogbd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llogbd64.c
+++ b/ieee754r/llogbd64.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llquantexpd128.c
+++ b/ieee754r/llquantexpd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llquantexpd32.c
+++ b/ieee754r/llquantexpd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llquantexpd64.c
+++ b/ieee754r/llquantexpd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llrintd128.c
+++ b/ieee754r/llrintd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llrintd32.c
+++ b/ieee754r/llrintd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llrintd64.c
+++ b/ieee754r/llrintd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llroundd128.c
+++ b/ieee754r/llroundd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llroundd32.c
+++ b/ieee754r/llroundd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/llroundd64.c
+++ b/ieee754r/llroundd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log10d128.c
+++ b/ieee754r/log10d128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log10d32.c
+++ b/ieee754r/log10d32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log10d64.c
+++ b/ieee754r/log10d64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log1pd128.c
+++ b/ieee754r/log1pd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log1pd32.c
+++ b/ieee754r/log1pd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log1pd64.c
+++ b/ieee754r/log1pd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log2d128.c
+++ b/ieee754r/log2d128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log2d32.c
+++ b/ieee754r/log2d32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/log2d64.c
+++ b/ieee754r/log2d64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/logbd128.c
+++ b/ieee754r/logbd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/logbd32.c
+++ b/ieee754r/logbd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/logbd64.c
+++ b/ieee754r/logbd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/logd128.c
+++ b/ieee754r/logd128.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/logd32.c
+++ b/ieee754r/logd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/logd64.c
+++ b/ieee754r/logd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lrintd128.c
+++ b/ieee754r/lrintd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lrintd32.c
+++ b/ieee754r/lrintd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lrintd64.c
+++ b/ieee754r/lrintd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lroundd128.c
+++ b/ieee754r/lroundd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lroundd32.c
+++ b/ieee754r/lroundd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/lroundd64.c
+++ b/ieee754r/lroundd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/modfd128.c
+++ b/ieee754r/modfd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/modfd32.c
+++ b/ieee754r/modfd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/modfd64.c
+++ b/ieee754r/modfd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nand128.c
+++ b/ieee754r/nand128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nand32.c
+++ b/ieee754r/nand32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nand64.c
+++ b/ieee754r/nand64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nearbyintd128.c
+++ b/ieee754r/nearbyintd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nearbyintd32.c
+++ b/ieee754r/nearbyintd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nearbyintd64.c
+++ b/ieee754r/nearbyintd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextafterd128.c
+++ b/ieee754r/nextafterd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextafterd32.c
+++ b/ieee754r/nextafterd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextafterd64.c
+++ b/ieee754r/nextafterd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextdownd128.c
+++ b/ieee754r/nextdownd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextdownd32.c
+++ b/ieee754r/nextdownd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextdownd64.c
+++ b/ieee754r/nextdownd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nexttowardd128.c
+++ b/ieee754r/nexttowardd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nexttowardd32.c
+++ b/ieee754r/nexttowardd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nexttowardd64.c
+++ b/ieee754r/nexttowardd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextupd128.c
+++ b/ieee754r/nextupd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextupd32.c
+++ b/ieee754r/nextupd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/nextupd64.c
+++ b/ieee754r/nextupd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/powd128.c
+++ b/ieee754r/powd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/powd32.c
+++ b/ieee754r/powd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/powd64.c
+++ b/ieee754r/powd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/quantized128.c
+++ b/ieee754r/quantized128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/quantized32.c
+++ b/ieee754r/quantized32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/quantized64.c
+++ b/ieee754r/quantized64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/quantumd128.c
+++ b/ieee754r/quantumd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/quantumd32.c
+++ b/ieee754r/quantumd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/quantumd64.c
+++ b/ieee754r/quantumd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/remainderd128.c
+++ b/ieee754r/remainderd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/remainderd32.c
+++ b/ieee754r/remainderd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/remainderd64.c
+++ b/ieee754r/remainderd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/rintd128.c
+++ b/ieee754r/rintd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/rintd32.c
+++ b/ieee754r/rintd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/rintd64.c
+++ b/ieee754r/rintd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/roundd128.c
+++ b/ieee754r/roundd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/roundd32.c
+++ b/ieee754r/roundd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/roundd64.c
+++ b/ieee754r/roundd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/roundevend128.c
+++ b/ieee754r/roundevend128.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/roundevend32.c
+++ b/ieee754r/roundevend32.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/roundevend64.c
+++ b/ieee754r/roundevend64.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/samequantumd128.c
+++ b/ieee754r/samequantumd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/samequantumd32.c
+++ b/ieee754r/samequantumd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/samequantumd64.c
+++ b/ieee754r/samequantumd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/scalblnd128.c
+++ b/ieee754r/scalblnd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/scalblnd32.c
+++ b/ieee754r/scalblnd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/scalblnd64.c
+++ b/ieee754r/scalblnd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/scalbnd128.c
+++ b/ieee754r/scalbnd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/scalbnd32.c
+++ b/ieee754r/scalbnd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/scalbnd64.c
+++ b/ieee754r/scalbnd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/signbitd128.c
+++ b/ieee754r/signbitd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/signbitd32.c
+++ b/ieee754r/signbitd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/signbitd64.c
+++ b/ieee754r/signbitd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sind128.c
+++ b/ieee754r/sind128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sind32.c
+++ b/ieee754r/sind32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sind64.c
+++ b/ieee754r/sind64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sinhd128.c
+++ b/ieee754r/sinhd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sinhd32.c
+++ b/ieee754r/sinhd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sinhd64.c
+++ b/ieee754r/sinhd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sqrtd128.c
+++ b/ieee754r/sqrtd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sqrtd32.c
+++ b/ieee754r/sqrtd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/sqrtd64.c
+++ b/ieee754r/sqrtd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/t_expd128.h
+++ b/ieee754r/t_expd128.h
@@ -21,8 +21,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/t_logd128.h
+++ b/ieee754r/t_logd128.h
@@ -21,8 +21,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tand128.c
+++ b/ieee754r/tand128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tand32.c
+++ b/ieee754r/tand32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tand64.c
+++ b/ieee754r/tand64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tanhd128.c
+++ b/ieee754r/tanhd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tanhd32.c
+++ b/ieee754r/tanhd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tanhd64.c
+++ b/ieee754r/tanhd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tgammad128.c
+++ b/ieee754r/tgammad128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tgammad32.c
+++ b/ieee754r/tgammad32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/tgammad64.c
+++ b/ieee754r/tgammad64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/truncd128.c
+++ b/ieee754r/truncd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/truncd32.c
+++ b/ieee754r/truncd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/ieee754r/truncd64.c
+++ b/ieee754r/truncd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/include/convert.h
+++ b/include/convert.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/decode.h
+++ b/include/decode.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/dfp.h
+++ b/include/dfp.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/include/dfpacc.h
+++ b/include/dfpacc.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/dfpfenv_private.h
+++ b/include/dfpfenv_private.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/dfpmacro.h
+++ b/include/dfpmacro.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/dfpstdlib_private.h
+++ b/include/dfpstdlib_private.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/dfpwchar_private.h
+++ b/include/dfpwchar_private.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/fmt_dfp.h
+++ b/include/fmt_dfp.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/get_digits.h
+++ b/include/get_digits.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/gstdint.h
+++ b/include/gstdint.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/ieee754r_private.h
+++ b/include/ieee754r_private.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/init_dfp.h
+++ b/include/init_dfp.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/libdfp-symbols.h
+++ b/include/libdfp-symbols.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/printf_dfp.h
+++ b/include/printf_dfp.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/printf-hooks/fmt_d128.c
+++ b/printf-hooks/fmt_d128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/printf-hooks/fmt_d32.c
+++ b/printf-hooks/fmt_d32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/printf-hooks/fmt_d64.c
+++ b/printf-hooks/fmt_d64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/printf-hooks/init_dfp.c
+++ b/printf-hooks/init_dfp.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/printf-hooks/printf_dfp.c
+++ b/printf-hooks/printf_dfp.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/strfromd32.c
+++ b/stdlib/strfromd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/strtod128.c
+++ b/stdlib/strtod128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/strtod64.c
+++ b/stdlib/strtod64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/wcstod128.c
+++ b/stdlib/wcstod128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/wcstod32.c
+++ b/stdlib/wcstod32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/stdlib/wcstod64.c
+++ b/stdlib/wcstod64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/bid/Makefile
+++ b/sysdeps/bid/Makefile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License version 2.1 along with the Decimal Floating Point C Library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307 USA.
+# if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/bid/bid-private.c
+++ b/sysdeps/bid/bid-private.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/bid/bid-private.h
+++ b/sysdeps/bid/bid-private.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/bid/decode.c
+++ b/sysdeps/bid/decode.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/bid/symbol-hacks.h
+++ b/sysdeps/bid/symbol-hacks.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/dpd/decimal_float128.c
+++ b/sysdeps/dpd/decimal_float128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/dpd/decode.c
+++ b/sysdeps/dpd/decode.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/dpd/dpd-private.c
+++ b/sysdeps/dpd/dpd-private.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/dpd/dpd-private.h
+++ b/sysdeps/dpd/dpd-private.h
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/dpd/symbol-hacks.h
+++ b/sysdeps/dpd/symbol-hacks.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/binpowof10.c
+++ b/sysdeps/generic/binpowof10.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/convert_helpers.h
+++ b/sysdeps/generic/convert_helpers.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/decpowof2.c
+++ b/sysdeps/generic/decpowof2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/dfp_inline.h
+++ b/sysdeps/generic/dfp_inline.h
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 #ifndef _DFP_INLINE_H

--- a/sysdeps/generic/fenv_libdfp.h
+++ b/sysdeps/generic/fenv_libdfp.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/libdfp-version.c
+++ b/sysdeps/generic/libdfp-version.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/mapround.c
+++ b/sysdeps/generic/mapround.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/mapround.h
+++ b/sysdeps/generic/mapround.h
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/math_private.h
+++ b/sysdeps/generic/math_private.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/numdigits.h
+++ b/sysdeps/generic/numdigits.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/generic/ticonstants.c
+++ b/sysdeps/generic/ticonstants.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/ceild128.c
+++ b/sysdeps/powerpc/dfpu/ceild128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/ceild32.c
+++ b/sysdeps/powerpc/dfpu/ceild32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/ceild64.c
+++ b/sysdeps/powerpc/dfpu/ceild64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/convert_helpers.h
+++ b/sysdeps/powerpc/dfpu/convert_helpers.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/copysignd128.c
+++ b/sysdeps/powerpc/dfpu/copysignd128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/copysignd32.c
+++ b/sysdeps/powerpc/dfpu/copysignd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/copysignd64.c
+++ b/sysdeps/powerpc/dfpu/copysignd64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/dfp_inline.h
+++ b/sysdeps/powerpc/dfpu/dfp_inline.h
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/expd32.c
+++ b/sysdeps/powerpc/dfpu/expd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fabsd128.c
+++ b/sysdeps/powerpc/dfpu/fabsd128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fabsd32.c
+++ b/sysdeps/powerpc/dfpu/fabsd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fabsd64.c
+++ b/sysdeps/powerpc/dfpu/fabsd64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fe_decround.c
+++ b/sysdeps/powerpc/dfpu/fe_decround.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/floord128.c
+++ b/sysdeps/powerpc/dfpu/floord128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/floord32.c
+++ b/sysdeps/powerpc/dfpu/floord32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/floord64.c
+++ b/sysdeps/powerpc/dfpu/floord64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fpclassifyd128.c
+++ b/sysdeps/powerpc/dfpu/fpclassifyd128.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fpclassifyd32.c
+++ b/sysdeps/powerpc/dfpu/fpclassifyd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/fpclassifyd64.c
+++ b/sysdeps/powerpc/dfpu/fpclassifyd64.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isfinited128.c
+++ b/sysdeps/powerpc/dfpu/isfinited128.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isfinited32.c
+++ b/sysdeps/powerpc/dfpu/isfinited32.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isfinited64.c
+++ b/sysdeps/powerpc/dfpu/isfinited64.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isinfd128.c
+++ b/sysdeps/powerpc/dfpu/isinfd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isinfd32.c
+++ b/sysdeps/powerpc/dfpu/isinfd32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isinfd64.c
+++ b/sysdeps/powerpc/dfpu/isinfd64.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isnand128.c
+++ b/sysdeps/powerpc/dfpu/isnand128.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isnand32.c
+++ b/sysdeps/powerpc/dfpu/isnand32.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isnand64.c
+++ b/sysdeps/powerpc/dfpu/isnand64.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isnormald128.c
+++ b/sysdeps/powerpc/dfpu/isnormald128.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more normalormation.  */
 

--- a/sysdeps/powerpc/dfpu/isnormald32.c
+++ b/sysdeps/powerpc/dfpu/isnormald32.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/isnormald64.c
+++ b/sysdeps/powerpc/dfpu/isnormald64.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/issignalingd128.c
+++ b/sysdeps/powerpc/dfpu/issignalingd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/issignalingd32.c
+++ b/sysdeps/powerpc/dfpu/issignalingd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/issignalingd64.c
+++ b/sysdeps/powerpc/dfpu/issignalingd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/llquantexpd128.c
+++ b/sysdeps/powerpc/dfpu/llquantexpd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/llquantexpd32.c
+++ b/sysdeps/powerpc/dfpu/llquantexpd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/llquantexpd64.c
+++ b/sysdeps/powerpc/dfpu/llquantexpd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/logd32.c
+++ b/sysdeps/powerpc/dfpu/logd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/nearbyintd128.c
+++ b/sysdeps/powerpc/dfpu/nearbyintd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/nearbyintd32.c
+++ b/sysdeps/powerpc/dfpu/nearbyintd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/nearbyintd64.c
+++ b/sysdeps/powerpc/dfpu/nearbyintd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/numdigits.h
+++ b/sysdeps/powerpc/dfpu/numdigits.h
@@ -21,8 +21,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/powd32.c
+++ b/sysdeps/powerpc/dfpu/powd32.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/quantized128.c
+++ b/sysdeps/powerpc/dfpu/quantized128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/quantized32.c
+++ b/sysdeps/powerpc/dfpu/quantized32.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/quantized64.c
+++ b/sysdeps/powerpc/dfpu/quantized64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/quantumd128.c
+++ b/sysdeps/powerpc/dfpu/quantumd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/quantumd32.c
+++ b/sysdeps/powerpc/dfpu/quantumd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/quantumd64.c
+++ b/sysdeps/powerpc/dfpu/quantumd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/roundd128.c
+++ b/sysdeps/powerpc/dfpu/roundd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/roundd32.c
+++ b/sysdeps/powerpc/dfpu/roundd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/roundd64.c
+++ b/sysdeps/powerpc/dfpu/roundd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/roundevend128.c
+++ b/sysdeps/powerpc/dfpu/roundevend128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/roundevend32.c
+++ b/sysdeps/powerpc/dfpu/roundevend32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/roundevend64.c
+++ b/sysdeps/powerpc/dfpu/roundevend64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/samequantumd128.c
+++ b/sysdeps/powerpc/dfpu/samequantumd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/samequantumd32.c
+++ b/sysdeps/powerpc/dfpu/samequantumd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/samequantumd64.c
+++ b/sysdeps/powerpc/dfpu/samequantumd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/truncd128.c
+++ b/sysdeps/powerpc/dfpu/truncd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/truncd32.c
+++ b/sysdeps/powerpc/dfpu/truncd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/truncd64.c
+++ b/sysdeps/powerpc/dfpu/truncd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/dfpu/trunctdsd2.c
+++ b/sysdeps/powerpc/dfpu/trunctdsd2.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/extendddtf.c
+++ b/sysdeps/powerpc/extendddtf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/extendsdtf.c
+++ b/sysdeps/powerpc/extendsdtf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/extendtftd.c
+++ b/sysdeps/powerpc/extendtftd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/fenv_libdfp.h
+++ b/sysdeps/powerpc/fenv_libdfp.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/powerpc32/sysdep.h
+++ b/sysdeps/powerpc/powerpc32/sysdep.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/powerpc64/sysdep.h
+++ b/sysdeps/powerpc/powerpc64/sysdep.h
@@ -14,8 +14,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/sysdep.h
+++ b/sysdeps/powerpc/sysdep.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/trunctdtf.c
+++ b/sysdeps/powerpc/trunctdtf.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/trunctfdd.c
+++ b/sysdeps/powerpc/trunctfdd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/powerpc/trunctfsd.c
+++ b/sysdeps/powerpc/trunctfsd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/ceild128.c
+++ b/sysdeps/s390/dfpu/ceild128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/ceild32.c
+++ b/sysdeps/s390/dfpu/ceild32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/ceild64.c
+++ b/sysdeps/s390/dfpu/ceild64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/convert_helpers.h
+++ b/sysdeps/s390/dfpu/convert_helpers.h
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/copysignd128.c
+++ b/sysdeps/s390/dfpu/copysignd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/copysignd32.c
+++ b/sysdeps/s390/dfpu/copysignd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/copysignd64.c
+++ b/sysdeps/s390/dfpu/copysignd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/extendddtf.c
+++ b/sysdeps/s390/dfpu/extendddtf.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/extendsdtd2.c
+++ b/sysdeps/s390/dfpu/extendsdtd2.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/extendsdtf.c
+++ b/sysdeps/s390/dfpu/extendsdtf.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/extendtftd.c
+++ b/sysdeps/s390/dfpu/extendtftd.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fabsd128.c
+++ b/sysdeps/s390/dfpu/fabsd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/fabsd32.c
+++ b/sysdeps/s390/dfpu/fabsd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fabsd64.c
+++ b/sysdeps/s390/dfpu/fabsd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/fdimd128.c
+++ b/sysdeps/s390/dfpu/fdimd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/fdimd32.c
+++ b/sysdeps/s390/dfpu/fdimd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fdimd64.c
+++ b/sysdeps/s390/dfpu/fdimd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/fe_decround.c
+++ b/sysdeps/s390/dfpu/fe_decround.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/floord128.c
+++ b/sysdeps/s390/dfpu/floord128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/floord32.c
+++ b/sysdeps/s390/dfpu/floord32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/floord64.c
+++ b/sysdeps/s390/dfpu/floord64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/fmaxd128.c
+++ b/sysdeps/s390/dfpu/fmaxd128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fmaxd32.c
+++ b/sysdeps/s390/dfpu/fmaxd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fmaxd64.c
+++ b/sysdeps/s390/dfpu/fmaxd64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fmind128.c
+++ b/sysdeps/s390/dfpu/fmind128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fmind32.c
+++ b/sysdeps/s390/dfpu/fmind32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fmind64.c
+++ b/sysdeps/s390/dfpu/fmind64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fpclassifyd128.c
+++ b/sysdeps/s390/dfpu/fpclassifyd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/fpclassifyd32.c
+++ b/sysdeps/s390/dfpu/fpclassifyd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/fpclassifyd64.c
+++ b/sysdeps/s390/dfpu/fpclassifyd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/isfinited128.c
+++ b/sysdeps/s390/dfpu/isfinited128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/isfinited32.c
+++ b/sysdeps/s390/dfpu/isfinited32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/isfinited64.c
+++ b/sysdeps/s390/dfpu/isfinited64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/isgreaterd128.c
+++ b/sysdeps/s390/dfpu/isgreaterd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/isgreaterd32.c
+++ b/sysdeps/s390/dfpu/isgreaterd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/isgreaterd64.c
+++ b/sysdeps/s390/dfpu/isgreaterd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/isgreaterequald128.c
+++ b/sysdeps/s390/dfpu/isgreaterequald128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/isgreaterequald32.c
+++ b/sysdeps/s390/dfpu/isgreaterequald32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/isgreaterequald64.c
+++ b/sysdeps/s390/dfpu/isgreaterequald64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/isinfd128.c
+++ b/sysdeps/s390/dfpu/isinfd128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/isinfd32.c
+++ b/sysdeps/s390/dfpu/isinfd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/isinfd64.c
+++ b/sysdeps/s390/dfpu/isinfd64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/islessd128.c
+++ b/sysdeps/s390/dfpu/islessd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/islessd32.c
+++ b/sysdeps/s390/dfpu/islessd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/islessd64.c
+++ b/sysdeps/s390/dfpu/islessd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/islessequald128.c
+++ b/sysdeps/s390/dfpu/islessequald128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/islessequald32.c
+++ b/sysdeps/s390/dfpu/islessequald32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/islessequald64.c
+++ b/sysdeps/s390/dfpu/islessequald64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/islessgreaterd128.c
+++ b/sysdeps/s390/dfpu/islessgreaterd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/islessgreaterd32.c
+++ b/sysdeps/s390/dfpu/islessgreaterd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/islessgreaterd64.c
+++ b/sysdeps/s390/dfpu/islessgreaterd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/isnand128.c
+++ b/sysdeps/s390/dfpu/isnand128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/isnand32.c
+++ b/sysdeps/s390/dfpu/isnand32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/isnand64.c
+++ b/sysdeps/s390/dfpu/isnand64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/isnormald128.c
+++ b/sysdeps/s390/dfpu/isnormald128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/isnormald32.c
+++ b/sysdeps/s390/dfpu/isnormald32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/isnormald64.c
+++ b/sysdeps/s390/dfpu/isnormald64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/issignalingd128.c
+++ b/sysdeps/s390/dfpu/issignalingd128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/issignalingd32.c
+++ b/sysdeps/s390/dfpu/issignalingd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/issignalingd64.c
+++ b/sysdeps/s390/dfpu/issignalingd64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/llquantexpd128.c
+++ b/sysdeps/s390/dfpu/llquantexpd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/llquantexpd32.c
+++ b/sysdeps/s390/dfpu/llquantexpd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/llquantexpd64.c
+++ b/sysdeps/s390/dfpu/llquantexpd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/llrintd128.c
+++ b/sysdeps/s390/dfpu/llrintd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/llrintd32.c
+++ b/sysdeps/s390/dfpu/llrintd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/llrintd64.c
+++ b/sysdeps/s390/dfpu/llrintd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/llroundd128.c
+++ b/sysdeps/s390/dfpu/llroundd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/llroundd32.c
+++ b/sysdeps/s390/dfpu/llroundd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/llroundd64.c
+++ b/sysdeps/s390/dfpu/llroundd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/lrintd128.c
+++ b/sysdeps/s390/dfpu/lrintd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/lrintd32.c
+++ b/sysdeps/s390/dfpu/lrintd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/lrintd64.c
+++ b/sysdeps/s390/dfpu/lrintd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/lroundd128.c
+++ b/sysdeps/s390/dfpu/lroundd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/lroundd32.c
+++ b/sysdeps/s390/dfpu/lroundd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/lroundd64.c
+++ b/sysdeps/s390/dfpu/lroundd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/nearbyintd128.c
+++ b/sysdeps/s390/dfpu/nearbyintd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/nearbyintd32.c
+++ b/sysdeps/s390/dfpu/nearbyintd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/nearbyintd64.c
+++ b/sysdeps/s390/dfpu/nearbyintd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/numdigits.h
+++ b/sysdeps/s390/dfpu/numdigits.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/quantized128.c
+++ b/sysdeps/s390/dfpu/quantized128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/quantized32.c
+++ b/sysdeps/s390/dfpu/quantized32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/quantized64.c
+++ b/sysdeps/s390/dfpu/quantized64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/quantumd128.c
+++ b/sysdeps/s390/dfpu/quantumd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/quantumd32.c
+++ b/sysdeps/s390/dfpu/quantumd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/quantumd64.c
+++ b/sysdeps/s390/dfpu/quantumd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/rintd128.c
+++ b/sysdeps/s390/dfpu/rintd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/rintd32.c
+++ b/sysdeps/s390/dfpu/rintd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/rintd64.c
+++ b/sysdeps/s390/dfpu/rintd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/roundd128.c
+++ b/sysdeps/s390/dfpu/roundd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/roundd32.c
+++ b/sysdeps/s390/dfpu/roundd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/roundd64.c
+++ b/sysdeps/s390/dfpu/roundd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/roundevend128.c
+++ b/sysdeps/s390/dfpu/roundevend128.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/roundevend32.c
+++ b/sysdeps/s390/dfpu/roundevend32.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/roundevend64.c
+++ b/sysdeps/s390/dfpu/roundevend64.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/samequantumd128.c
+++ b/sysdeps/s390/dfpu/samequantumd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/samequantumd32.c
+++ b/sysdeps/s390/dfpu/samequantumd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/samequantumd64.c
+++ b/sysdeps/s390/dfpu/samequantumd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/signbitd128.c
+++ b/sysdeps/s390/dfpu/signbitd128.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/signbitd32.c
+++ b/sysdeps/s390/dfpu/signbitd32.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/signbitd64.c
+++ b/sysdeps/s390/dfpu/signbitd64.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/truncd128.c
+++ b/sysdeps/s390/dfpu/truncd128.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 128

--- a/sysdeps/s390/dfpu/truncd32.c
+++ b/sysdeps/s390/dfpu/truncd32.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/truncd64.c
+++ b/sysdeps/s390/dfpu/truncd64.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 #define _DECIMAL_SIZE 64

--- a/sysdeps/s390/dfpu/trunctdsd2.c
+++ b/sysdeps/s390/dfpu/trunctdsd2.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/trunctdtf.c
+++ b/sysdeps/s390/dfpu/trunctdtf.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/trunctfdd.c
+++ b/sysdeps/s390/dfpu/trunctfdd.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/dfpu/trunctfsd.c
+++ b/sysdeps/s390/dfpu/trunctfsd.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/s390/fenv_libdfp.h
+++ b/sysdeps/s390/fenv_libdfp.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/adddd3.c
+++ b/sysdeps/soft-dfp/adddd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/addsd3.c
+++ b/sysdeps/soft-dfp/addsd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/addtd3.c
+++ b/sysdeps/soft-dfp/addtd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/bid/Makefile
+++ b/sysdeps/soft-dfp/bid/Makefile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License version 2.1 along with the Decimal Floating Point C Library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307 USA.
+# if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/bid/fe_decround.c
+++ b/sysdeps/soft-dfp/bid/fe_decround.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/bid/numdigits.h
+++ b/sysdeps/soft-dfp/bid/numdigits.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/candtruncd32.c
+++ b/sysdeps/soft-dfp/candtruncd32.c
@@ -21,8 +21,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/candtruncd64.c
+++ b/sysdeps/soft-dfp/candtruncd64.c
@@ -21,8 +21,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/decroundtls.c
+++ b/sysdeps/soft-dfp/decroundtls.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/decroundtls.h
+++ b/sysdeps/soft-dfp/decroundtls.h
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/divdd3.c
+++ b/sysdeps/soft-dfp/divdd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/divsd3.c
+++ b/sysdeps/soft-dfp/divsd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/divtd3.c
+++ b/sysdeps/soft-dfp/divtd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/dpd/Makefile
+++ b/sysdeps/soft-dfp/dpd/Makefile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License version 2.1 along with the Decimal Floating Point C Library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307 USA.
+# if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/dpd/numdigits.h
+++ b/sysdeps/soft-dfp/dpd/numdigits.h
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/eqdd2.c
+++ b/sysdeps/soft-dfp/eqdd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/eqsd2.c
+++ b/sysdeps/soft-dfp/eqsd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/eqtd2.c
+++ b/sysdeps/soft-dfp/eqtd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/extendddtd2.c
+++ b/sysdeps/soft-dfp/extendddtd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/extendsddd2.c
+++ b/sysdeps/soft-dfp/extendsddd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/extendsdtd2.c
+++ b/sysdeps/soft-dfp/extendsdtd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fe_decround.c
+++ b/sysdeps/soft-dfp/fe_decround.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixdddi.c
+++ b/sysdeps/soft-dfp/fixdddi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixddsi.c
+++ b/sysdeps/soft-dfp/fixddsi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixsddi.c
+++ b/sysdeps/soft-dfp/fixsddi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixsdsi.c
+++ b/sysdeps/soft-dfp/fixsdsi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixtddi.c
+++ b/sysdeps/soft-dfp/fixtddi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixtdsi.c
+++ b/sysdeps/soft-dfp/fixtdsi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixunsdddi.c
+++ b/sysdeps/soft-dfp/fixunsdddi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixunsddsi.c
+++ b/sysdeps/soft-dfp/fixunsddsi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixunssddi.c
+++ b/sysdeps/soft-dfp/fixunssddi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixunssdsi.c
+++ b/sysdeps/soft-dfp/fixunssdsi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixunstddi.c
+++ b/sysdeps/soft-dfp/fixunstddi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/fixunstdsi.c
+++ b/sysdeps/soft-dfp/fixunstdsi.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatdidd.c
+++ b/sysdeps/soft-dfp/floatdidd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatdisd.c
+++ b/sysdeps/soft-dfp/floatdisd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatditd.c
+++ b/sysdeps/soft-dfp/floatditd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatsidd.c
+++ b/sysdeps/soft-dfp/floatsidd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatsisd.c
+++ b/sysdeps/soft-dfp/floatsisd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatsitd.c
+++ b/sysdeps/soft-dfp/floatsitd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatunsdidd.c
+++ b/sysdeps/soft-dfp/floatunsdidd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatunsdisd.c
+++ b/sysdeps/soft-dfp/floatunsdisd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatunsditd.c
+++ b/sysdeps/soft-dfp/floatunsditd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatunssidd.c
+++ b/sysdeps/soft-dfp/floatunssidd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatunssisd.c
+++ b/sysdeps/soft-dfp/floatunssisd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/floatunssitd.c
+++ b/sysdeps/soft-dfp/floatunssitd.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/gedd2.c
+++ b/sysdeps/soft-dfp/gedd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/gesd2.c
+++ b/sysdeps/soft-dfp/gesd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/getd2.c
+++ b/sysdeps/soft-dfp/getd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/gtdd2.c
+++ b/sysdeps/soft-dfp/gtdd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/gtsd2.c
+++ b/sysdeps/soft-dfp/gtsd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/gttd2.c
+++ b/sysdeps/soft-dfp/gttd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/ledd2.c
+++ b/sysdeps/soft-dfp/ledd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/lesd2.c
+++ b/sysdeps/soft-dfp/lesd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/letd2.c
+++ b/sysdeps/soft-dfp/letd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/ltdd2.c
+++ b/sysdeps/soft-dfp/ltdd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/ltsd2.c
+++ b/sysdeps/soft-dfp/ltsd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/lttd2.c
+++ b/sysdeps/soft-dfp/lttd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/muldd3.c
+++ b/sysdeps/soft-dfp/muldd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/mulsd3.c
+++ b/sysdeps/soft-dfp/mulsd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/multd3.c
+++ b/sysdeps/soft-dfp/multd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/nedd2.c
+++ b/sysdeps/soft-dfp/nedd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/nesd2.c
+++ b/sysdeps/soft-dfp/nesd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/netd2.c
+++ b/sysdeps/soft-dfp/netd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/subdd3.c
+++ b/sysdeps/soft-dfp/subdd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/subsd3.c
+++ b/sysdeps/soft-dfp/subsd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/subtd3.c
+++ b/sysdeps/soft-dfp/subtd3.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/truncddsd2.c
+++ b/sysdeps/soft-dfp/truncddsd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/trunctddd2.c
+++ b/sysdeps/soft-dfp/trunctddd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/trunctdsd2.c
+++ b/sysdeps/soft-dfp/trunctdsd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/unorddd2.c
+++ b/sysdeps/soft-dfp/unorddd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/unordsd2.c
+++ b/sysdeps/soft-dfp/unordsd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/sysdeps/soft-dfp/unordtd2.c
+++ b/sysdeps/soft-dfp/unordtd2.c
@@ -18,8 +18,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/decode.h
+++ b/tests/decode.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/gen-auto-dfp-tests.c
+++ b/tests/gen-auto-dfp-tests.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information. */
 

--- a/tests/libdfp-test.c
+++ b/tests/libdfp-test.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/scaffold.c
+++ b/tests/scaffold.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-amort.c
+++ b/tests/test-amort.c
@@ -19,8 +19,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-bfp-conversions.c
+++ b/tests/test-bfp-conversions.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-cast-to-overflow.c
+++ b/tests/test-cast-to-overflow.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-cast-to-underflow.c
+++ b/tests/test-cast-to-underflow.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see dfp/COPYING.txt for more information.  */
 

--- a/tests/test-decode.c
+++ b/tests/test-decode.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-fenv.c
+++ b/tests/test-fenv.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-fix.c
+++ b/tests/test-fix.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-float.c
+++ b/tests/test-float.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-get_digits.c
+++ b/tests/test-get_digits.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-getexp.c
+++ b/tests/test-getexp.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-illogb.c
+++ b/tests/test-illogb.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-inexact-exception.c
+++ b/tests/test-inexact-exception.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-istream.cpp
+++ b/tests/test-istream.cpp
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-left_justify.c
+++ b/tests/test-left_justify.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-math-macros.c
+++ b/tests/test-math-macros.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-numdigits.c
+++ b/tests/test-numdigits.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-ostream-g-spec.cpp
+++ b/tests/test-ostream-g-spec.cpp
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-ostream.cpp
+++ b/tests/test-ostream.cpp
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-printf.c
+++ b/tests/test-printf.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-setexp.c
+++ b/tests/test-setexp.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-strfrom.c
+++ b/tests/test-strfrom.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-strtod.c
+++ b/tests/test-strtod.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-type-conversions.c
+++ b/tests/test-type-conversions.c
@@ -15,8 +15,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 

--- a/tests/test-wchar.c
+++ b/tests/test-wchar.c
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License version 2.1 along with the Decimal Floating Point C Library;
-   if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-   Suite 330, Boston, MA 02111-1307 USA.
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
    Please see libdfp/COPYING.txt for more information.  */
 


### PR DESCRIPTION
In 2005, the FSF moved to a new address.
Update all files with that new address.

Link: https://www.fsf.org/news/fsf-responds-to-linuxworld-in-boston
Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@ascii.art.br>