### PR TITLE
sysdeps/soft-dfp: respect rounding mode for elementary operations

### DIFF
--- a/sysdeps/soft-dfp/addsd3.c
+++ b/sysdeps/soft-dfp/addsd3.c
@@ -38,6 +38,8 @@
 
 #include <dfpmacro.h>
 #include "dfpacc.h"
+#include "mapround.h"
+
 DEC_TYPE
 PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
 {
@@ -45,6 +47,7 @@ PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
   decNumber dn_x, dn_y, dn_result;
   decContext context;
   decContextDefault(&context, DEFAULT_CONTEXT);
+  context.round = __dn_getround();
 
   FUNC_CONVERT_TO_DN(&x, &dn_x);
   FUNC_CONVERT_TO_DN(&y, &dn_y);

--- a/sysdeps/soft-dfp/divsd3.c
+++ b/sysdeps/soft-dfp/divsd3.c
@@ -37,6 +37,7 @@
 
 #include <dfpmacro.h>
 #include "dfpacc.h"
+#include "mapround.h"
 DEC_TYPE
 PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
 {
@@ -44,6 +45,7 @@ PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
   decNumber dn_x, dn_y, dn_result;
   decContext context;
   decContextDefault(&context, DEFAULT_CONTEXT);
+  context.round = __dn_getround();
 
   FUNC_CONVERT_TO_DN(&x, &dn_x);
   FUNC_CONVERT_TO_DN(&y, &dn_y);

--- a/sysdeps/soft-dfp/mulsd3.c
+++ b/sysdeps/soft-dfp/mulsd3.c
@@ -37,6 +37,7 @@
 
 #include "dfpacc.h"
 #include <dfpmacro.h>
+#include "mapround.h"
 DEC_TYPE
 PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
 {
@@ -44,6 +45,7 @@ PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
   decNumber dn_x, dn_y, dn_result;
   decContext context;
   decContextDefault(&context, DEFAULT_CONTEXT);
+  context.round = __dn_getround();
 
   FUNC_CONVERT_TO_DN(&x, &dn_x);
   FUNC_CONVERT_TO_DN(&y, &dn_y);

--- a/sysdeps/soft-dfp/subsd3.c
+++ b/sysdeps/soft-dfp/subsd3.c
@@ -37,6 +37,7 @@
 
 #include "dfpacc.h"
 #include <dfpmacro.h>
+#include "mapround.h"
 DEC_TYPE
 PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
 {
@@ -44,6 +45,7 @@ PREFIXED_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y)
   decNumber dn_x, dn_y, dn_result;
   decContext context;
   decContextDefault(&context, DEFAULT_CONTEXT);
+  context.round = __dn_getround();
 
   FUNC_CONVERT_TO_DN(&x, &dn_x);
   FUNC_CONVERT_TO_DN(&y, &dn_y);


### PR DESCRIPTION
add/subtract/multiply/divide must respect the correct rounding mode when using the soft-dfp implementation.

fixes #201