### PR TITLE
Fix fma functions

### DIFF
--- a/ieee754r/fmad32.c
+++ b/ieee754r/fmad32.c
@@ -40,68 +40,34 @@
 
 #include <dfpmacro.h>
 
-static DEC_TYPE
-IEEE_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y, DEC_TYPE z)
+DEC_TYPE
+INTERNAL_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y, DEC_TYPE z)
 {
   decContext context;
   decNumber dn_result;
   DEC_TYPE result;
   decNumber dn_x;
   decNumber dn_y;
-  decNumber dn_product;
   decNumber dn_z;
 
   FUNC_CONVERT_TO_DN (&x, &dn_x);
   FUNC_CONVERT_TO_DN (&y, &dn_y);
   FUNC_CONVERT_TO_DN (&z, &dn_z);
 
-  /*  If x or y is NaN, return NaN */
-  if (decNumberIsNaN (&dn_x) || decNumberIsNaN (&dn_y))
-    return x+y;
-
-  /*  Domain error if x or y is Inf, the other is 0 */
-  if (  (decNumberIsInfinite (&dn_x) && decNumberIsZero (&dn_y)) ||
-	(decNumberIsInfinite (&dn_y) && decNumberIsZero (&dn_x))  )
-    {
-      DFP_EXCEPT (FE_INVALID);
-      return DFP_NAN;
-    }
-  /* If x and y are not 0,Inf or Inf,0, and z is NaN, return NaN */
-  if (decNumberIsNaN (&dn_z))
-    return z+z;
-
   decContextDefault (&context, DEFAULT_CONTEXT);
-  decNumberMultiply (&dn_product, &dn_x, &dn_y, &context);
+  decNumberFMA (&dn_result, &dn_x, &dn_y, &dn_z, &context);
 
-  /* Domain error if x*y = Inf and z=Inf (with opposite signs) */
-  if (decNumberIsInfinite (&dn_product) && decNumberIsInfinite (&dn_z) &&
-	(decNumberIsNegative (&dn_product) != decNumberIsNegative (&dn_z)))
+  if (context.status != 0)
     {
-      DFP_EXCEPT (FE_INVALID);
-      return DFP_NAN;
+      if (context.status & DEC_Invalid_operation)
+	{
+	  DFP_EXCEPT (FE_INVALID);
+	}
     }
-  decNumberAdd (&dn_result, &dn_product, &dn_z, &context);
 
   FUNC_CONVERT_FROM_DN (&dn_result, &result, &context);
 
   return result;
-}
-
-DEC_TYPE
-INTERNAL_FUNCTION_NAME (DEC_TYPE x, DEC_TYPE y, DEC_TYPE z)
-{
-  DEC_TYPE r = IEEE_FUNCTION_NAME (x, y, z);
-  if ( (FUNC_D(__isinf) (x) && y == DFP_CONSTANT(0.0)) ||
-	(FUNC_D(__isinf) (y) && x == DFP_CONSTANT(0.0)) )
-      DFP_ERRNO(EDOM);
-  else if (FUNC_D (__isinf) (z))
-    {
-      int isneg = FUNC_D(__signbit) (x) ^ FUNC_D(__signbit) (y);
-      int inf = FUNC_D(__isinf) (x) | FUNC_D(__isinf) (y);
-      if ( inf && FUNC_D (__signbit) (z) != isneg)
-	DFP_ERRNO (EDOM);
-    }
-  return r;
 }
 
 weak_alias (INTERNAL_FUNCTION_NAME, EXTERNAL_FUNCTION_NAME)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,7 +42,8 @@ libdfp_c_tests = test-printf test-amort test-decode test-inexact-exception \
 		 test-fminmag-d32 test-fminmag-d64 test-fminmag-d128 \
 		 test-math-macros test-strfrom \
 		 test-nextup-d32 test-nextup-d64 test-nextup-d128 \
-		 test-nextdown-d32 test-nextdown-d64 test-nextdown-d128
+		 test-nextdown-d32 test-nextdown-d64 test-nextdown-d128 \
+		 test-fma-d32 test-fma-d64 test-fma-d128
 
 ifeq ($(libdfp-has-timode),yes)
 libdfp_c_tests += test-fix test-float

--- a/tests/fma.input
+++ b/tests/fma.input
@@ -1,0 +1,6 @@
+# name fma
+# arg1 decimal
+# arg2 decimal
+# arg3 decimal
+# ret  decimal
+DEC_MAX 2 -DEC_MAX DEC_MAX

--- a/tests/libdfp-test.c
+++ b/tests/libdfp-test.c
@@ -64,6 +64,13 @@
    COMMON_TEST_CLEANUP;                                                 \
   } while (0)
 
+#define RUN_TEST_fff_f(FUNC_NAME, ARG_STR, ARG1, ARG2, ARG3, EXPECTED, EXTRAFLAGS) \
+  do {                                                                  \
+   COMMON_TEST_SETUP (FUNC_NAME, ARG_STR);                              \
+   check_float (test_name, FUNC (FUNC_NAME) (ARG1, ARG2, ARG3), EXPECTED, EXTRAFLAGS); \
+   COMMON_TEST_CLEANUP;                                                 \
+  } while (0)
+
 #define RUN_TEST_f_i(FUNC_NAME, ARG_STR, ARG, EXPECTED, EXTRAFLAGS)	\
   do {                                                                  \
    COMMON_TEST_SETUP (FUNC_NAME, ARG_STR);                              \


### PR DESCRIPTION
This is a decnumber wrapper, so use the provided decnumber implementation which correctly preserves intermediate precision and correctness.

Ideally, the tests should be expanded to cover more interesting cases where rounding effects can be observes between FMA and non-FMA cases.

Fixes: #259