### PR TITLE
Lots of strtodN (and ldexpdN) fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -284,6 +284,7 @@ libdfp_tests = $(libdfp_c_tests) $(libdfp_cxx_tests) check-abi-libdfp check-loca
 
 test-printf.os: $(top_builddir)/printf_dfp.os
 test-strtod.os: $(top_builddir)/strtod32.os $(top_builddir)/strtod64.os $(top_builddir)/strtod128.os
+test-strtod-locale.os: $(top_builddir)/strtod32.os $(top_builddir)/strtod64.os $(top_builddir)/strtod128.os
 
 # Empty rule which simply makes the libdfp_tests .so's dependent on
 # tests/libdfp-test.c so that when the libdfp-test file changes all of the test .so

--- a/ieee754r/ldexpd32.c
+++ b/ieee754r/ldexpd32.c
@@ -42,6 +42,8 @@
 
 #include "dfp_inline.h"
 
+#define EMAX_RAW PASTE(DECIMAL,PASTE(_DECIMAL_SIZE,_Emax_raw))
+
 static DEC_TYPE
 IEEE_FUNCTION_NAME (DEC_TYPE x, int y)
 {
@@ -50,10 +52,22 @@ IEEE_FUNCTION_NAME (DEC_TYPE x, int y)
   int minexp = PASTE(DECIMAL,PASTE(_DECIMAL_SIZE,_Emin));
   int p = PASTE(DECIMAL,PASTE(_DECIMAL_SIZE,_Pmax));
 
-#if NUMDIGITS_SUPPORT==1
   newexp = FUNC_D (getexp) (x) + y;
-  if (newexp > PASTE(DECIMAL,PASTE(_DECIMAL_SIZE,_Emax)))
+  if (__builtin_isnan (x) || __builtin_isinf (x))
+    return x + x; 
+  else if (x == DFP_CONSTANT(0.))
     {
+       /* The C23 standard says nothing about which 0 to return. Adjust and
+	* clamp it based on the format.  This simplifies usage with strtodN. */
+       newexp = newexp < minexp ? minexp : newexp;
+       newexp = newexp > EMAX_RAW ? EMAX_RAW : newexp;
+       result = FUNC_D(setexp) (x, newexp);
+    }
+  else if (newexp > EMAX_RAW)
+    {
+    /* Some values might fit. Shift the exponent via multiplication. */
+    if (newexp <= PASTE(DECIMAL,PASTE(_DECIMAL_SIZE,_Emax)))
+      return FUNC_D(setexp) (x, 34) * FUNC_D(setexp) (1.DL, newexp - 34);
     result = FUNC_D(__copysign)(DFP_HUGE_VAL, x);
     DFP_EXCEPT (FE_OVERFLOW);
     }
@@ -73,33 +87,6 @@ IEEE_FUNCTION_NAME (DEC_TYPE x, int y)
     }
   else
     result = FUNC_D(setexp) (x, newexp);
-
-#else
-  decContext context;
-  decNumber dn_x;
-
-  FUNC_CONVERT_TO_DN (&x, &dn_x);
-  if (___decNumberIsNaN (&dn_x) || ___decNumberIsZero (&dn_x) ||
-	___decNumberIsInfinite (&dn_x))
-    return x+x;
-  if (y == 0)
-    return x;
-
-  /* ldexp(x,y) is just x*10**y, which is equivalent to increasing the exponent
-   * by y.  */
-  newexp = dn_x.exponent + y;
-  if(newexp > INT_MAX)
-    newexp = INT_MAX;
-  if(newexp < -INT_MAX)
-    newexp = -INT_MAX;
-  dn_x.exponent = newexp;
-
-  decContextDefault (&context, DEFAULT_CONTEXT);
-  FUNC_CONVERT_FROM_DN (&dn_x, &result, &context);
-
-  if (context.status & DEC_Overflow)
-    DFP_EXCEPT (FE_OVERFLOW);
-#endif
 
   return result;
 }

--- a/ieee754r/ldexpd32.c
+++ b/ieee754r/ldexpd32.c
@@ -74,14 +74,16 @@ IEEE_FUNCTION_NAME (DEC_TYPE x, int y)
   else if (newexp < minexp)
     {
     /* Check if the result might be subnormal. */
-    if( newexp > (minexp - p))
+    if( newexp >= (minexp - p))
       {
         result = FUNC_D(setexp) (x, minexp);
         /* Use a multiply so we correctly round whatever may shifts out. */
         tiny = FUNC_D(setexp) (1.DL, newexp - minexp);
-        return result * tiny;
+	result *= tiny;
+	if (result != DFP_CONSTANT(0.))
+          return result;
       }
-    result = DFP_CONSTANT(0.0);
+    result = DFP_CONSTANT(0.);
     DFP_EXCEPT (FE_UNDERFLOW);
     return result;
     }

--- a/ieee754r/ldexpd32.c
+++ b/ieee754r/ldexpd32.c
@@ -53,7 +53,7 @@ IEEE_FUNCTION_NAME (DEC_TYPE x, int y)
   int p = PASTE(DECIMAL,PASTE(_DECIMAL_SIZE,_Pmax));
 
   newexp = FUNC_D (getexp) (x) + y;
-  if (__builtin_isnan (x) || __builtin_isinf (x))
+  if (FUNC_D (__isnan) (x) || !FUNC_D (__isfinite) (x))
     return x + x; 
   else if (x == DFP_CONSTANT(0.))
     {

--- a/include/dfpmacro.h
+++ b/include/dfpmacro.h
@@ -130,6 +130,11 @@
 #define DFP_NAN			(DEC_TYPE)DEC_NAN
 #define DFP_INF			(DEC_TYPE)DEC_INFINITY
 
+/* Limits of the raw unbiased exponent for each format. */
+#define DECIMAL32_Emax_raw  90
+#define DECIMAL64_Emax_raw  369
+#define DECIMAL128_Emax_raw 6111
+
 #ifndef PASTE
 /* Ideally these shouldn't need to be used elsewhere outside of this file */
 # define PASTE(x,y) PASTE2(x,y)

--- a/include/dfpstdlib_private.h
+++ b/include/dfpstdlib_private.h
@@ -28,17 +28,9 @@
 
 #include <features.h>
 
-extern _Decimal32 __strtod32_internal (const char * __restrict nptr, char ** __restrict endptr, int group);
-extern _Decimal64 __strtod64_internal (const char * __restrict nptr, char ** __restrict endptr, int group);
-extern _Decimal128 __strtod128_internal (const char * __restrict nptr, char ** __restrict endptr, int group);
-
-hidden_proto (__strtod32_internal)
-hidden_proto (__strtod64_internal)
-hidden_proto (__strtod128_internal)
-
-extern _Decimal32 __strtod32_l_internal (const char * __restrict nptr, char ** __restrict endptr, int group, locale_t loc);
-extern _Decimal64 __strtod64_l_internal (const char * __restrict nptr, char ** __restrict endptr, int group, locale_t loc);
-extern _Decimal128 __strtod128_l_internal (const char * __restrict nptr, char ** __restrict endptr, int group, locale_t loc);
+extern _Decimal32 __strtod32_l_internal (const char * __restrict nptr, char ** __restrict endptr, locale_t loc);
+extern _Decimal64 __strtod64_l_internal (const char * __restrict nptr, char ** __restrict endptr, locale_t loc);
+extern _Decimal128 __strtod128_l_internal (const char * __restrict nptr, char ** __restrict endptr, locale_t loc);
 
 hidden_proto (__strtod32_l_internal)
 hidden_proto (__strtod64_l_internal)

--- a/include/dfpwchar_private.h
+++ b/include/dfpwchar_private.h
@@ -26,17 +26,9 @@
 #ifndef _DFPWCHAR_PRIVATE_H
 #define _DFPWCHAR_PRIVATE_H
 
-extern _Decimal32 __wcstod32_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, int group);
-extern _Decimal64 __wcstod64_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, int group);
-extern _Decimal128 __wcstod128_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, int group);
-
-hidden_proto (__wcstod32_internal)
-hidden_proto (__wcstod64_internal)
-hidden_proto (__wcstod128_internal)
-
-extern _Decimal32 __wcstod32_l_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, int group, locale_t loc);
-extern _Decimal64 __wcstod64_l_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, int group, locale_t loc);
-extern _Decimal128 __wcstod128_l_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, int group, locale_t loc);
+extern _Decimal32 __wcstod32_l_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, locale_t loc);
+extern _Decimal64 __wcstod64_l_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, locale_t loc);
+extern _Decimal128 __wcstod128_l_internal (const wchar_t * __restrict nptr, wchar_t ** __restrict endptr, locale_t loc);
 
 hidden_proto (__wcstod32_l_internal)
 hidden_proto (__wcstod64_l_internal)

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -750,36 +750,6 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 	cp = expp;
     }
 
-
-  /* We don't want to have to work with trailing zeroes after the radix.  */
-#if 0  /* Actually, for DFP, we do. */
-  if (dig_no > int_no)
-    {
-      while (expp[-1] == L_('0'))
-	{
-	  --expp;
-	  /*--exponent;*/  /* FIXME: This can't be here */
-	  --dig_no;
-	}
-      assert (dig_no >= int_no);
-    }
-
-  if (dig_no == int_no && dig_no > 0 && exponent < 0)
-    do
-      {
-	while (! ISDIGIT (expp[-1]))
-	  --expp;
-
-	if (expp[-1] != L_('0'))
-	  break;
-
-	--expp;
-	--dig_no;
-	--int_no;
-	++exponent;
-      }
-    while (dig_no > 0 && exponent < 0);
-#endif
  number_parsed:
 
   /* The whole string is parsed.  Store the address of the next character.  */
@@ -798,16 +768,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       int exp_max = MAX_10_EXP - MANT_DIG;
       exponent = (exponent > exp_max) ? exp_max : exponent;
 
-#if NUMDIGITS_SUPPORT==0
-      d32 += 1;
-      while(exponent-- > 0)  /* FIXME: this doesn't work right for exponent>0 */
-	d32 *= 10;
-      while(++exponent < 0)
-	d32 /= 10;
-      d32 -= d32;
-#else
       d32 = FUNC_D(setexp) (d32, exponent);
-#endif
 
       freelocale(C_locale);
       return negative ? -d32 : d32;
@@ -915,19 +876,6 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       /* Read the decimal part as a FLOAT.  */
       int digcnt = dig_no - int_no;
       
-  /* There might be radix characters in
-	    the string.  But these all can be ignored because we know the
-	    format of the number is correct and we have an exact number
-	    of characters to read.  */
-
-      /*do
-	{
-	  frac = frac/10 + *(startp+digcnt-1) - L_('0');
-	}
-      while (--digcnt > 0);
-      frac /= 10;
-
-      d32 += frac;*/
       int_no = 0;
       do
         {
@@ -951,12 +899,6 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
     while (--digcnt > 0);
     }
 
-#if NUMDIGITS_SUPPORT==0
-  while(exponent-- > 0)
-    d32 *= 10;
-  while(++exponent < 0)
-    d32 /= 10;
-#else
   /* Computed underflow after normalization.  */
   if ( exponent <  (__DEC_MIN_EXP__ - __DEC_MANT_DIG__))
     {
@@ -973,8 +915,6 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       d32 = FUNC_D(left_justify) (d32);
 
   d32 = FUNC_D(setexp) (d32, FUNC_D (getexp) (d32) + exponent);
-
-#endif
 
   freelocale(C_locale);
   return negative? -d32:d32;

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -484,6 +484,8 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 		/* The closing brace is missing.  Only match the NAN
 		   part.  */
 		cp = startp;
+	      else if (*cp == L_(')'))
+		cp++;
 #if 0
 	      else
 		{

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -335,6 +335,8 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
   const STRING_TYPE *expp;
   /* Total number of digit and number of digits in integer part.  */
   int dig_no, int_no, lead_zero;
+  /* Total number of digits read into mantissa. */
+  int dig_read;
   /* Contains the last character read.  */
   CHAR_TYPE c;
   __locale_t C_locale;
@@ -828,6 +830,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       return FLOAT_ZERO;
     }
   /* Read in the integer portion of the input string */
+  dig_read = 0;
   if (int_no > 0)
     {
       /* Read the integer part as a d32.  */
@@ -865,6 +868,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 	    }
 #endif
 	  d32 = d32 * 10 + (*startp - L_('0'));
+	  dig_read++;
 	  ++startp;
 	}
       while (--digcnt > 0);
@@ -875,6 +879,10 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
     {
       /* Read the decimal part as a FLOAT.  */
       int digcnt = dig_no - int_no;
+
+      /* The rounding value. */
+      FLOAT rnd = 0.;
+      bool is_5 = false;
       
       int_no = 0;
       do
@@ -887,16 +895,40 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 	startp += decimal_len;
 #endif
 
-        /* We need the extra digit to get proper rounding.  */
-	if (int_no < MANT_DIG + 1)
+	if (dig_read < MANT_DIG)
 	  {
 	    d32 = d32*10 + (*startp - L_('0'));
 	    ++startp;
 	    --exponent;
 	    int_no++;
+	    dig_read++;
+	  }
+	else
+	  {
+            /* Figure out the rounding value. */
+            if (dig_read == MANT_DIG)
+	      {
+		rnd = (*startp - L_('0')) * (FLOAT)(0.1DF);
+
+		/* If it is not 5, we're done. */
+		is_5 = *startp == L_('5');
+		if (!is_5)
+		  break;
+	      }
+	    else if (is_5 && *startp != L_('0'))
+	      {
+		rnd = 0.6;
+		break;
+	      }
+	    dig_read++;
+	    ++startp;
 	  }
 	}
-    while (--digcnt > 0);
+      while (--digcnt > 0);
+
+      /* Apply rounding, only if non-zero. */
+      if (rnd != FLOAT_ZERO)
+        d32 += rnd;
     }
 
   /* Computed underflow after normalization.  */
@@ -914,7 +946,8 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
   if (exponent > (__DEC_MAX_EXP__ - __DEC_MANT_DIG__))
       d32 = FUNC_D(left_justify) (d32);
 
-  d32 = FUNC_D(setexp) (d32, FUNC_D (getexp) (d32) + exponent);
+  /* Rescale exponent (and possibly round) based on exponent. */
+  d32 = FUNC_D(__ldexp) (d32, exponent);
 
   freelocale(C_locale);
   return negative? -d32:d32;

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -823,7 +823,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
     }
 
   /* Obvious underflow before normalization.  */
-  if (exponent < MIN_10_EXP - MANT_DIG + 1 )
+  if (exponent < (MIN_10_EXP - MANT_DIG))
     {
       __set_errno (ERANGE);
       freelocale(C_locale);
@@ -931,8 +931,8 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
         d32 += rnd;
     }
 
-  /* Computed underflow after normalization.  */
-  if ( exponent <  (__DEC_MIN_EXP__ - __DEC_MANT_DIG__))
+  /* Flush to zero if the value is smaller than the rounding digit.  */
+  if ( (exponent + dig_read) <  (__DEC_MIN_EXP__ - __DEC_MANT_DIG__))
     {
       __set_errno (ERANGE);
       freelocale(C_locale);
@@ -947,7 +947,12 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       d32 = FUNC_D(left_justify) (d32);
 
   /* Rescale exponent (and possibly round) based on exponent. */
+  FLOAT d32_mant = d32;
   d32 = FUNC_D(__ldexp) (d32, exponent);
+
+  /* Setting the exponent may result in underflow too.  */
+  if (d32 == FLOAT_ZERO && d32_mant != FLOAT_ZERO)
+    __set_errno (ERANGE);
 
   freelocale(C_locale);
   return negative? -d32:d32;

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -198,7 +198,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
   int cnt;
 #endif
 
-  C_locale = newlocale(LC_ALL_MASK, setlocale (LC_ALL, NULL),NULL);
+  C_locale = newlocale(LC_ALL_MASK, "C", NULL);
 
   /* Find the locale's decimal point character.  */
 #ifdef USE_WIDE_CHAR
@@ -282,7 +282,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 	      do
 		++cp;
 	      while ((*cp >= L_('0') && *cp <= L_('9'))
-		     || (TOLOWER (*cp) >= L_('a') && TOLOWER (*cp) <= L_('z'))
+		     || (TOLOWER_C (*cp) >= L_('a') && TOLOWER_C (*cp) <= L_('z'))
 		     || *cp == L_('_'));
 
 	      if (*cp != L_(')'))

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -156,171 +156,10 @@ extern unsigned long long int ____wcstoull_l_internal (const wchar_t *, wchar_t 
 			   _a > _b ? _a : _b; })
 #endif
 
-/* Find the maximum prefix of the string between BEGIN and END which
-   satisfies the grouping rules.  It is assumed that at least one digit
-   follows BEGIN directly.  */
-
-static const STRING_TYPE *
-#ifdef USE_WIDE_CHAR
-__correctly_grouped_prefixwc (const STRING_TYPE *begin, const STRING_TYPE *end,
-			      wchar_t thousands,
-#else
-__correctly_grouped_prefixmb (const STRING_TYPE *begin, const STRING_TYPE *end,
-			      const char *thousands,
-#endif
-			      const char *grouping)
-{
-#ifndef USE_WIDE_CHAR
-  size_t thousands_len;
-  int cnt;
-#endif
-
-  if (grouping == NULL)
-    return end;
-
-#ifndef USE_WIDE_CHAR
-  thousands_len = strlen (thousands);
-#endif
-
-  while (end > begin)
-    {
-      const STRING_TYPE *cp = end - 1;
-      const char *gp = grouping;
-
-      /* Check first group.  */
-      while (cp >= begin)
-	{
-#ifdef USE_WIDE_CHAR
-	  if (*cp == thousands)
-	    break;
-#else
-	  if (cp[thousands_len - 1] == *thousands)
-	    {
-	      for (cnt = 1; thousands[cnt] != '\0'; ++cnt)
-		if (thousands[cnt] != cp[thousands_len - 1 - cnt])
-		  break;
-	      if (thousands[cnt] == '\0')
-		break;
-	    }
-#endif
-	  --cp;
-	}
-
-      /* We allow the representation to contain no grouping at all even if
-	 the locale specifies we can have grouping.  */
-      if (cp < begin)
-	return end;
-
-      if (end - cp == (int) *gp + 1)
-	{
-	  /* This group matches the specification.  */
-
-	  const STRING_TYPE *new_end;
-
-	  if (cp < begin)
-	    /* There is just one complete group.  We are done.  */
-	    return end;
-
-	  /* CP points to a thousands separator character.  The preceding
-	     remainder of the string from BEGIN to NEW_END is the part we
-	     will consider if there is a grouping error in this trailing
-	     portion from CP to END.  */
-	  new_end = cp - 1;
-
-	  /* Loop while the grouping is correct.  */
-	  while (1)
-	    {
-	      /* Get the next grouping rule.  */
-	      ++gp;
-	      if (*gp == 0)
-		/* If end is reached use last rule.  */
-	        --gp;
-
-	      /* Skip the thousands separator.  */
-	      --cp;
-
-	      if (*gp == CHAR_MAX
-#if CHAR_MIN < 0
-		  || *gp < 0
-#endif
-		  )
-	        {
-	          /* No more thousands separators are allowed to follow.  */
-	          while (cp >= begin)
-		    {
-#ifdef USE_WIDE_CHAR
-		      if (*cp == thousands)
-			break;
-#else
-		      for (cnt = 0; thousands[cnt] != '\0'; ++cnt)
-			if (thousands[cnt] != cp[thousands_len - cnt - 1])
-			  break;
-		      if (thousands[cnt] == '\0')
-			break;
-#endif
-		      --cp;
-		    }
-
-	          if (cp < begin)
-		    /* OK, only digits followed.  */
-		    return end;
-	        }
-	      else
-	        {
-		  /* Check the next group.  */
-	          const STRING_TYPE *group_end = cp;
-
-		  while (cp >= begin)
-		    {
-#ifdef USE_WIDE_CHAR
-		      if (*cp == thousands)
-			break;
-#else
-		      for (cnt = 0; thousands[cnt] != '\0'; ++cnt)
-			if (thousands[cnt] != cp[thousands_len - cnt - 1])
-			  break;
-		      if (thousands[cnt] == '\0')
-			break;
-#endif
-		      --cp;
-		    }
-
-		  if (cp < begin && group_end - cp <= (int) *gp)
-		    /* Final group is correct.  */
-		    return end;
-
-		  if (cp < begin || group_end - cp != (int) *gp)
-		    /* Incorrect group.  Punt.  */
-		    break;
-		}
-	    }
-
-	  /* The trailing portion of the string starting at NEW_END
-	     contains a grouping error.  So we will look for a correctly
-	     grouped number in the preceding portion instead.  */
-	  end = new_end;
-	}
-      else
-	{
-	  /* Even the first group was wrong; determine maximum shift.  */
-	  if (end - cp > (int) *gp + 1)
-	    end = cp + (int) *gp + 1;
-	  else if (cp < begin)
-	    /* This number does not fill the first group, but is correct.  */
-	    return end;
-	  else
-	    /* CP points to a thousands separator character.  */
-	    end = cp;
-	}
-    }
-
-  return MAX (begin, end);
-}
-
 /* This is of the form __strtod32_l_internal() */
 FLOAT
 FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
-		int group, locale_t loc)
+		locale_t loc)
 {
   FLOAT d32 = FLOAT_ZERO;
 
@@ -354,48 +193,12 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
   const char *decimal;
   size_t decimal_len;
 #endif
-  /* The thousands character of the current locale.  */
-#ifdef USE_WIDE_CHAR
-  const char *thousandsmb = NULL;
-  wchar_t thousands = L'\0';
-#else
-  const char *thousands = NULL;
+#ifndef USE_WIDE_CHAR
   /* Used in several places.  */
   int cnt;
 #endif
-  /* The numeric grouping specification of the current locale,
-     in the format described in <locale.h>.  */
-  const char *grouping;
 
   C_locale = newlocale(LC_ALL_MASK, setlocale (LC_ALL, NULL),NULL);
-
-  if (group)
-    {
-      //grouping = _NL_CURRENT (LC_NUMERIC, GROUPING);
-      grouping = nl_langinfo (__GROUPING);
-      if (*grouping <= 0 || *grouping == CHAR_MAX)
-	grouping = NULL;
-      else
-	{
-	  /* Figure out the thousands separator character.  */
-#ifdef USE_WIDE_CHAR
-	  thousandsmb = nl_langinfo(_NL_NUMERIC_THOUSANDS_SEP_WC);
-	  mbrtowc(&thousands,thousandsmb, CHAR_MAX, NULL);
-
-	  if (thousands == L'\0')
-	    grouping = NULL;
-#else
-	  thousands = nl_langinfo (__THOUSANDS_SEP);
-	  if (*thousands == '\0')
-	    {
-	      thousands = NULL;
-	      grouping = NULL;
-	    }
-#endif
-	}
-    }
-  else
-    grouping = NULL;
 
   /* Find the locale's decimal point character.  */
 #ifdef USE_WIDE_CHAR
@@ -519,34 +322,12 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       RETURN (FLOAT_ZERO, nptr);
     }
 
-  /* Record the start of the digits, in case we will check their grouping.  */
+  /* Record the start of the digits.  */
   start_of_digits = startp = cp;
 
   /* Ignore leading zeroes.  This helps us to avoid useless computations.  */
-#ifdef USE_WIDE_CHAR
-  while (c == L'0' || ((wint_t) thousands != L'\0' && c == (wint_t) thousands))
+  while (c == L_('0'))
     c = *++cp;
-#else
-  if (thousands == NULL)
-    while (c == '0')
-      c = *++cp;
-  else
-    {
-      /* We also have the multibyte thousands string.  */
-      while (1)
-	{
-	  if (c != '0')
-	    {
-	      for (cnt = 0; thousands[cnt] != '\0'; ++cnt)
-		if (c != thousands[cnt])
-		  break;
-	      if (thousands[cnt] != '\0')
-		break;
-	    }
-	  c = *++cp;
-	}
-    }
-#endif
 
   /* If no other digit but a '0' is found the result is 0.0.
      Return current read pointer.  */
@@ -561,15 +342,7 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 #endif
       && ((CHAR_TYPE) TOLOWER (c) != L_('e')))
     {
-#ifdef USE_WIDE_CHAR
-      tp = __correctly_grouped_prefixwc (start_of_digits, cp, thousands,
-					 grouping);
-#else
-      tp = __correctly_grouped_prefixmb (start_of_digits, cp, thousands,
-					 grouping);
-#endif
-      /* If TP is at the start of the digits, there was no correctly
-	 grouped prefix of the string; so no number found.  */
+      tp = cp;
       freelocale(C_locale);
       RETURN (negative ? -FLOAT_ZERO : FLOAT_ZERO,
               tp == start_of_digits ? nptr : tp);
@@ -584,69 +357,9 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       if (c >= L_('0') && c <= L_('9'))
 	++dig_no;
       else
-	{
-#ifdef USE_WIDE_CHAR
-	  if ((wint_t) thousands == L'\0' || c != (wint_t) thousands)
-	    /* Not a digit or separator: end of the integer part.  */
-	    break;
-#else
-	  if (thousands == NULL)
-	    break;
-	  else
-	    {
-	      for (cnt = 0; thousands[cnt] != '\0'; ++cnt)
-		if (thousands[cnt] != cp[cnt])
-		  break;
-	      if (thousands[cnt] != '\0')
-		break;
-	    }
-#endif
-	}
+	/* Not a digit or separator: end of the integer part.  */
+	break;
       c = *++cp;
-    }
-
-  if (grouping && dig_no > 0)
-    {
-      /* Check the grouping of the digits.  */
-#ifdef USE_WIDE_CHAR
-      tp = __correctly_grouped_prefixwc (start_of_digits, cp, thousands,
-					 grouping);
-#else
-      tp = __correctly_grouped_prefixmb (start_of_digits, cp, thousands,
-					 grouping);
-#endif
-      if (cp != tp)
-	{
-	  /* Less than the entire string was correctly grouped.  */
-
-	  if (tp == start_of_digits)
-	    {
-	      /* No valid group of numbers at all: no valid number.  */
-	      freelocale(C_locale);
-	      RETURN (FLOAT_ZERO, nptr);
-	    }
-
-	  if (tp < startp)
-	    {
-	      /* The number is validly grouped, but consists
-		 only of zeroes.  The whole value is zero.  */
-	      freelocale(C_locale);
-	      RETURN (negative ? -FLOAT_ZERO : FLOAT_ZERO, tp);
-	    }
-
-	  /* Recompute DIG_NO so we won't read more digits than
-	     are properly grouped.  */
-	  cp = tp;
-	  dig_no = 0;
-	  for (tp = startp; tp < cp; ++tp)
-	    if (*tp >= L_('0') && *tp <= L_('9'))
-	      ++dig_no;
-
-	  int_no = dig_no;
-	  lead_zero = 0;
-
-	  goto number_parsed;
-	}
     }
 
   /* We have the number digits in the integer part.  Whether these are all or
@@ -751,8 +464,6 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       else
 	cp = expp;
     }
-
- number_parsed:
 
   /* The whole string is parsed.  Store the address of the next character.  */
   if (endptr)
@@ -912,23 +623,6 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 }
 hidden_def(FUNCTION_L_INTERNAL)
 
-/* This is of the form __strtod32_internal() */
-FLOAT
-FUNCTION_INTERNAL (const STRING_TYPE *nptr, STRING_TYPE **endptr, int group)
-{
-  char * curlocale;
-  __locale_t cur_locale_t;
-  FLOAT ret_val;
-
-  curlocale = setlocale(LC_ALL,NULL);
-  cur_locale_t = newlocale(LC_ALL_MASK, curlocale, NULL);
-
-  ret_val = FUNCTION_L_INTERNAL (nptr,endptr,group,cur_locale_t);
-  freelocale(cur_locale_t);
-  return ret_val;
-}
-hidden_def(FUNCTION_INTERNAL)
-
 /* This is of the form strtod32() */
 FLOAT
 #ifdef weak_function
@@ -943,7 +637,7 @@ FUNCTION_NAME (const STRING_TYPE *nptr, STRING_TYPE **endptr)
   curlocale = setlocale(LC_ALL,NULL);
   cur_locale_t = newlocale(LC_ALL_MASK, curlocale, NULL);
 
-  ret_val = FUNCTION_L_INTERNAL(nptr, endptr, 0, cur_locale_t);
+  ret_val = FUNCTION_L_INTERNAL(nptr, endptr, cur_locale_t);
   freelocale(cur_locale_t);
   return ret_val;
 }

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -270,8 +270,8 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
 
       if (TOLOWER_C (c) == L_('n') && STRNCASECMP (cp, L_("nan"), 3) == 0)
 	{
-	  /* Return NaN.  */
-	  FLOAT retval = DEC_NAN;
+	  /* Return NaN.  Cast before negating, otherwise the compiler ignores the sign.  */
+	  FLOAT retval = negative ? -(FLOAT) DEC_NAN : DEC_NAN;
 
 	  cp += 3;
 

--- a/stdlib/strtod32.c
+++ b/stdlib/strtod32.c
@@ -829,107 +829,60 @@ FUNCTION_L_INTERNAL (const STRING_TYPE * nptr, STRING_TYPE ** endptr,
       freelocale(C_locale);
       return FLOAT_ZERO;
     }
-  /* Read in the integer portion of the input string */
+
   dig_read = 0;
-  if (int_no > 0)
+  FLOAT rnd = 0.;
+  int rnd_dig = 0;
+
+  /* The number has been validated.  We know the number of integer digits,
+   * and the number of fractional digits.  */
+  while (dig_read < dig_no)
     {
-      /* Read the integer part as a d32.  */
-      int digcnt = int_no;
-
-      while (int_no > MAX_10_EXP + 1)
-	{
-	  digcnt--;
-	  exponent++;
-	}
-      do
-	{
-	  /* There might be thousands separators or radix characters in
-	    the string.  But these all can be ignored because we know the
-	    format of the number is correct and we have an exact number
-	    of characters to read.  */
-#ifdef USE_WIDE_CHAR
-	  if (*startp < L_('0') || *startp > L_('9'))
-	    ++startp;
-#else
-	  if (*startp < L_('0') || *startp > L_('9'))
-	    {
-	      int inner = 0;
-	      if (thousands != NULL && *startp == *thousands
-		  && ({
-			for (inner = 1; thousands[inner] != '\0'; ++inner)
-			  if (thousands[inner] != startp[inner])
-			    break;
-			thousands[inner] == '\0';
-		      })
-		  )
-		startp += inner;
-	      else
-		startp += decimal_len;
-	    }
-#endif
-	  d32 = d32 * 10 + (*startp - L_('0'));
-	  dig_read++;
-	  ++startp;
-	}
-      while (--digcnt > 0);
-
-    }
-  /* If we haven't filled our datatype, read in the fractional digits */
-  if (int_no <= MANT_DIG && dig_no > int_no)
-    {
-      /* Read the decimal part as a FLOAT.  */
-      int digcnt = dig_no - int_no;
-
-      /* The rounding value. */
-      FLOAT rnd = 0.;
-      bool is_5 = false;
-      
-      int_no = 0;
-      do
-        {
-#ifdef USE_WIDE_CHAR
+      /* Skip non-digit characters.  */
       if (*startp < L_('0') || *startp > L_('9'))
-	++startp;
-#else
-      if (*startp < '0' || *startp > '9')
-	startp += decimal_len;
-#endif
-
-	if (dig_read < MANT_DIG)
-	  {
-	    d32 = d32*10 + (*startp - L_('0'));
-	    ++startp;
-	    --exponent;
-	    int_no++;
-	    dig_read++;
-	  }
-	else
-	  {
-            /* Figure out the rounding value. */
-            if (dig_read == MANT_DIG)
-	      {
-		rnd = (*startp - L_('0')) * (FLOAT)(0.1DF);
-
-		/* If it is not 5, we're done. */
-		is_5 = *startp == L_('5');
-		if (!is_5)
-		  break;
-	      }
-	    else if (is_5 && *startp != L_('0'))
-	      {
-		rnd = 0.6;
-		break;
-	      }
-	    dig_read++;
-	    ++startp;
-	  }
+        {
+	  ++startp;
+	  continue;
 	}
-      while (--digcnt > 0);
 
-      /* Apply rounding, only if non-zero. */
-      if (rnd != FLOAT_ZERO)
-        d32 += rnd;
+      if (dig_read < MANT_DIG)
+	{
+          d32 = d32 * 10 + (*startp - L_('0'));
+          dig_read++;
+	}
+      else if (dig_read == MANT_DIG)
+        {
+          /* The rounding digit.  */
+	  rnd_dig++;
+          dig_read++;
+	  rnd = (*startp - L_('0')) * (FLOAT)(0.1DF);
+	  /* If it is not 5 or 0, no need to find a tie breaker.  */
+	  if (!(*startp == L_('5')) || (*startp == L_('0')))
+	    break;
+	}
+      else
+	{
+	  /* The guard digit: round a non-zero remainder to 0.01.  */
+	  rnd_dig++;
+          dig_read++;
+	  if (*startp != L_('0'))
+            {
+               rnd += (FLOAT) 0.01DF;
+	       break;
+	    }
+	}
+      startp++;
     }
+
+  /* Apply rounding, only if non-zero. */
+  if (rnd != FLOAT_ZERO)
+    d32 += rnd;
+
+  /* Adjust exponent if rounding occurred */
+  if (int_no > MANT_DIG)
+    exponent += int_no - MANT_DIG;
+  else if (dig_read > int_no)
+    exponent -= dig_read - rnd_dig - int_no;
 
   /* Flush to zero if the value is smaller than the rounding digit.  */
   if ( (exponent + dig_read) <  (__DEC_MIN_EXP__ - __DEC_MANT_DIG__))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,6 @@
 libdfp_c_tests = test-printf test-amort test-decode test-inexact-exception \
-		 test-strtod test-cast-to-overflow test-numdigits test-get_digits \
+		 test-strtod test-strtod-locale test-cast-to-overflow \
+		 test-numdigits test-get_digits \
 		 test-fenv test-bfp-conversions test-type-conversions test-wchar \
 		 test-getexp test-setexp test-left_justify test-cast-to-underflow \
 		 test-fpclassify-d32 test-fpclassify-d64 test-fpclassify-d128 \

--- a/tests/ldexp.input
+++ b/tests/ldexp.input
@@ -6,6 +6,7 @@
 1.0 1 10.0
 1.0 0 1.0
 1.0 -1 0.1
+6e-398 -1 DEC_SUBNORMAL_MIN		decimal64
 
 # Verify large right justified numbers.
 1.e90              1 10.e90             decimal32

--- a/tests/ldexp.input
+++ b/tests/ldexp.input
@@ -7,6 +7,19 @@
 1.0 0 1.0
 1.0 -1 0.1
 
+# Verify large right justified numbers.
+1.e90              1 10.e90             decimal32
+1.e369             1 10.e369            decimal64
+1.e6111            1 10.e6111           decimal128
+1.e96              1 Inf                decimal32
+1.e384             1 Inf                decimal64
+1.e6144            1 Inf                decimal128
+
+# Special case inputs
+NaN                1     NaN
+Inf                1     Inf 
+-Inf               1     -Inf
+0                  10000 0
 
 # Verify subnormal exponent math is correct
 DEC_MIN            1 1E-94             decimal32

--- a/tests/scaffold.c
+++ b/tests/scaffold.c
@@ -27,6 +27,7 @@
 
 static int fail = 0;
 static int testnum = 0;
+static int verbose = 1; // TODO: Old tests are verbose, update tests to accept a verbose option.
 
 /* String compare macros  */
 #ifndef _SC
@@ -41,9 +42,9 @@ static int testnum = 0;
 #define _SC_P(f,l,x,y) do { \
   ++testnum; \
   if(strcmp(x,y)) { \
-    fprintf(stderr, "%-3d Error:   Expected: \"%s\"\n             Result:   \"%s\"\n    in: %s:%d.\n\n", testnum,x,y,f,l); \
+    fprintf(stdout, "%-3d Error:   Expected: \"%s\"\n             Result:   \"%s\"\n    in: %s:%d.\n\n", testnum,x,y,f,l); \
     ++fail; \
-  } else { \
+  } else if (verbose) { \
     fprintf(stdout, "%-3d Success: Expected: \"%s\"\n             Result:   \"%s\"\n    in: %s:%d.\n\n", testnum,x,y,f,l); \
   } \
 } while (0)
@@ -164,7 +165,7 @@ static char buf[1024];
   __tmp = sprintf(buf, y, ##args); \
   _SC_P(f,l,x,buf); \
   if (__tmp != strlen(x)) { \
-    fprintf(stderr, "%-3d Error: fprintf didn't return the correct size." \
+    fprintf(stdout, "%-3d Error: fprintf didn't return the correct size." \
 	    "  Expected: \"%zd\"\n           " \
 	    "  Result:   \"%zd\"\n    in: %s:%d.\n\n", \
 	    testnum,strlen(x),__tmp,f,l); \
@@ -180,7 +181,7 @@ static char buf[1024];
   __tmp = fn(buf, n, fmt, d); \
   _SC_P(f,l,x,buf); \
   if (__tmp != len) { \
-    fprintf(stderr, "%-3d Error: " #fn " didn't return the correct size." \
+    fprintf(stdout, "%-3d Error: " #fn " didn't return the correct size." \
 	    "  Expected: \"%zd\"\n           " \
 	    "  Result:   \"%zd\"\n    in: %s:%d.\n\n", \
 	    testnum,len,__tmp,f,l); \
@@ -196,12 +197,12 @@ static char buf[1024];
   __tmp = fn(mybuf, 0, fmt, d); \
   testnum++; \
   if (__tmp != len) { \
-    fprintf(stderr, "%-3d Error: " #fn " didn't return the correct size." \
+    fprintf(stdout, "%-3d Error: " #fn " didn't return the correct size." \
 	    "  Expected: \"%zd\"\n  " \
 	    "  Result:   \"%zd\"\n    in: %s:%d.\n\n", \
 	    testnum,len,__tmp,f,l); \
     ++fail; \
-  } else { \
+  } else if (verbose) { \
     fprintf(stdout, "%-3d Success: " #fn \
 	    "  Expected: \"%zd\"\n  " \
 	    "  Result:   \"%zd\"\n    in: %s:%d.\n\n", \
@@ -230,30 +231,30 @@ static char buf[1024];
 
 /* Approximate Value Compare (takes a variation limit)  */
 #ifdef _WANT_AVC
-static char bufx[CHAR_MAX];
-static char bufy[CHAR_MAX];
-static char bufz[CHAR_MAX];
+static char bufx[512];
+static char bufy[512];
+static char bufz[512];
 #ifndef _AVC
 /* _AVC_P == Approximate Value Compare with Position  */
 #define _AVC_P(f,l,x,y,lim,fmt,lfmt) do { \
   ++testnum; \
-  memset(bufx,'\0',CHAR_MAX); \
-  memset(bufy,'\0',CHAR_MAX); \
-  memset(bufz,'\0',CHAR_MAX); \
+  memset(bufx,'\0',512); \
+  memset(bufy,'\0',512); \
+  memset(bufz,'\0',512); \
   /* Invokes printf dfp.  */  \
   sprintf(bufx, fmt, x); \
   sprintf(bufy, fmt, y); \
   sprintf(bufz, lfmt, lim); \
   if((y < (x-lim)) && (x > (y+lim))) { \
-    fprintf(stderr, "%-3d Error: Expected: \"%s\"\n", testnum, bufx); \
-    fprintf(stderr, "             Result: \"%s\"\n", bufy); \
-    fprintf(stderr, "                lim: \"%s\"\n", bufz); \
-    fprintf(stderr, "    in: %s:%d.\n\n", f,l); \
+    fprintf(stdout, "%-3d Error: Expected: \"%s\"\n", testnum, bufx); \
+    fprintf(stdout, "             Result: \"%s\"\n", bufy); \
+    fprintf(stdout, "                lim: \"%s\"\n", bufz); \
+    fprintf(stdout, "    in: %s:%d.\n\n", f,l); \
     ++fail; \
-  } else { \
+  } else if (verbose) { \
     fprintf(stdout, "%-3d Success: Expected: \"%s\"\n", testnum, bufx); \
     fprintf(stdout, "               Result: \"%s\"\n", bufy); \
-    fprintf(stderr, "                  lim: \"%s\"\n", bufz); \
+    fprintf(stdout, "                  lim: \"%s\"\n", bufz); \
     fprintf(stdout, "    in: %s:%d.\n\n", f,l); \
   } \
 } while (0)
@@ -271,33 +272,35 @@ static char bufz[CHAR_MAX];
 #endif /* _WANT_AVC  */
 
 #ifdef _WANT_VC
-static char bufx[CHAR_MAX];
-static char bufy[CHAR_MAX];
+static char bufx[512];
+static char bufy[512];
 #ifndef _VC
 /* _VC_P == Value Compare with Position  */
 #define _VC_P(f,l,x,y,fmt) do {                                 \
   ++testnum;                                                    \
-  memset(bufx,'\0',CHAR_MAX);                                   \
-  memset(bufy,'\0',CHAR_MAX);                                   \
+  memset(bufx,'\0',512);                                        \
+  memset(bufy,'\0',512);                                        \
   /* Invokes printf dfp.  */                                    \
   sprintf(bufx, fmt, x);                                        \
   sprintf(bufy, fmt, y);                                        \
   if ((isnan(x) && isnan(y)) ||                                 \
       (x == y))                                                 \
     {                                                           \
-      fprintf (stdout, "%-3d Success: Expected: \"%s\"\n",      \
+      if (verbose) {                                            \
+        fprintf (stdout, "%-3d Success: Expected: \"%s\"\n",    \
+          testnum, bufx);                                       \
+        fprintf (stdout, "              Result:   \"%s\"\n",    \
+          bufy);                                                \
+        fprintf (stdout, "in: %s:%i\n\n", f, l);                \
+      }                                                         \
+    }                                                           \
+  else                                                          \
+    {                                                           \
+      fprintf (stdout, "%-3d Error:   Expected: \"%s\"\n",      \
         testnum, bufx);                                         \
       fprintf (stdout, "              Result:   \"%s\"\n",      \
         bufy);                                                  \
       fprintf (stdout, "in: %s:%i\n\n", f, l);                  \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      fprintf (stderr, "%-3d Error:   Expected: \"%s\"\n",      \
-        testnum, bufx);                                         \
-      fprintf (stderr, "              Result:   \"%s\"\n",      \
-        bufy);                                                  \
-      fprintf (stderr, "in: %s:%i\n\n", f, l);                  \
       ++fail;                                                   \
     }                                                           \
 } while (0)
@@ -305,27 +308,29 @@ static char bufy[CHAR_MAX];
 /* _VC_P_CPP == Value Compare with Position for C++ types  */
 #define _VC_P_CPP(f,l,x,y,fmt) do {                             \
   ++testnum;                                                    \
-  memset(bufx,'\0',CHAR_MAX);                                   \
-  memset(bufy,'\0',CHAR_MAX);                                   \
+  memset(bufx,'\0',512);                                        \
+  memset(bufy,'\0',512);                                        \
   /* Invokes printf dfp.  */                                    \
   sprintf(bufx, fmt, x);                                        \
   sprintf(bufy, fmt, y);                                        \
   if ((isnan(x.__getval()) && isnan(y.__getval())) ||           \
       (x == y))                                                 \
     {                                                           \
-      fprintf (stdout, "%-3d Success: Expected: \"%s\"\n",      \
+      if (verbose) {                                            \
+        fprintf (stdout, "%-3d Success: Expected: \"%s\"\n",    \
+          testnum, bufx);                                       \
+        fprintf (stdout, "              Result:   \"%s\"\n",    \
+          bufy);                                                \
+        fprintf (stdout, "in: %s:%i\n\n", f, l);                \
+      }                                                         \
+    }                                                           \
+  else                                                          \
+    {                                                           \
+      fprintf (stdout, "%-3d Error:   Expected: \"%s\"\n",      \
         testnum, bufx);                                         \
       fprintf (stdout, "              Result:   \"%s\"\n",      \
         bufy);                                                  \
       fprintf (stdout, "in: %s:%i\n\n", f, l);                  \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      fprintf (stderr, "%-3d Error:   Expected: \"%s\"\n",      \
-        testnum, bufx);                                         \
-      fprintf (stderr, "              Result:   \"%s\"\n",      \
-        bufy);                                                  \
-      fprintf (stderr, "in: %s:%i\n\n", f, l);                  \
     }                                                           \
 } while (0)
 
@@ -355,21 +360,21 @@ static char bufy[CHAR_MAX];
 
 /* TODO: Finish this.  It doesn't do anything yet.  The purpose is to be able to
  * get the result in the expected precision.  */
-static char bufx[CHAR_MAX];
-static char bufy[CHAR_MAX];
+static char bufx[512];
+static char bufy[512];
 #ifndef _QC
 /* _QC_P == Quantize Compare with Position  */
 #define _QC_P(f,l,x,y,fmt,type) do { \
   ++testnum; \
-  memset(bufx,'\0',CHAR_MAX); \
-  memset(bufy,'\0',CHAR_MAX); \
+  memset(bufx,'\0',512); \
+  memset(bufy,'\0',512); \
   /* Invokes printf dfp.  */  \
   sprintf(bufx, fmt, x); \
   sprintf(bufy, fmt, y); \
   if(x!=y) { \
-    fprintf(stderr, "%-3d Error:   Expected: \"%s\"\n             Result:    \"%s\"\n    in: %s:%d.\n\n", testnum, bufx,bufy,f,l); \
+    fprintf(stdout, "%-3d Error:   Expected: \"%s\"\n             Result:    \"%s\"\n    in: %s:%d.\n\n", testnum, bufx,bufy,f,l); \
     ++fail; \
-  } else { \
+  } else if (verbose) { \
     fprintf(stdout, "%-3d Success: Expected: \"%s\"\n             Result:    \"%s\"\n    in: %s:%d.\n\n", testnum, bufx,bufy,f,l); \
   } \
 } while (0)
@@ -387,7 +392,7 @@ static char bufy[CHAR_MAX];
 
 
 #ifdef _WANT_DC
-static char dbuf[CHAR_MAX];
+static char dbuf[512];
 #ifndef _DC
 /* _DC == Decoded[32|64|128] Compare
  */
@@ -399,7 +404,7 @@ static char dbuf[CHAR_MAX];
  * is pre-determined.  Don't call this on Non-_Decimal values.  The outcome is
  * undefined.  */
 #define _DC_P(f,l,x,y) do { \
-  memset(dbuf,'\0',CHAR_MAX); \
+  memset(dbuf,'\0',512); \
   /* Invoke the correct decoded{32|64|128]() based on arg size.  */ \
   (sizeof (y) == sizeof (_Decimal128)? decoded128(y,&dbuf[0]): \
     (sizeof (y) == sizeof (_Decimal64)? decoded64(y,&dbuf[0]): \
@@ -431,7 +436,7 @@ static char dbuf[CHAR_MAX];
 /* Don't print anything if there are no failures.  */
 #define _REPORT() do { \
     if(fail) { \
-      fprintf(stderr, "Found %d failures.\n", fail); \
+      fprintf(stdout, "Found %d failures.\n", fail); \
     } \
 } while (0)
 

--- a/tests/test-strtod-locale.c
+++ b/tests/test-strtod-locale.c
@@ -65,6 +65,7 @@
 #define LOC_C	"C"
 #define LOC_DE	"de_DE.UTF-8"
 #define LOC_PS	"ps_AF.UTF-8"
+#define LOC_TR	"tr_TR.UTF-8"
 
 typedef enum {
   TEST_D32 = 1 << 0,
@@ -83,7 +84,8 @@ typedef struct {
   _Decimal128 expect;	/* Expected value.  Unless an entry is restricted to a
 			   single width it is exactly representable as a
 			   _Decimal32, so all three widths share it.  */
-  int qexp;		/* Expected quantum exponent.  */
+  int qexp;		/* Expected quantum exponent.  Ignored if EXPECT is
+			   not finite.  */
   test_type_flags types;
 } strtod_locale_test;
 
@@ -156,6 +158,43 @@ strtod_locale_test tests[] =
   {__LINE__, LOC_PS, INPUT_MB ("0" RADIX_HI), 1, 0, 0.DL, 0, TEST_ALL},
   {__LINE__, LOC_PS, INPUT_MB (RADIX_HI "25"), 0, 0, 0.DL, 0, TEST_ALL},
 
+  /* Infinities and NaNs, for reference in the C locale.  */
+  {__LINE__, LOC_C, INPUT ("inf"), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_C, INPUT ("-INFINITY"), 9, 9, -DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_C, INPUT ("NaN"), 3, 3, DEC_NAN, 0, TEST_ALL},
+  {__LINE__, LOC_C, INPUT ("nan(1_a)"), 8, 8, DEC_NAN, 0, TEST_ALL},
+
+  /* Neither the value nor the length of the radix character may affect
+     them.  */
+  {__LINE__, LOC_DE, INPUT ("Inf"), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_DE, INPUT ("-infinity"), 9, 9, -DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_DE, INPUT ("nan"), 3, 3, DEC_NAN, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT ("INF"), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT ("-Infinity"), 9, 9, -DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT ("NAN"), 3, 3, DEC_NAN, 0, TEST_ALL},
+
+  /* The radix character is not a digit, so it neither starts a number nor
+     extends one, and it is not part of an n-char-sequence.  */
+  {__LINE__, LOC_PS, INPUT ("inf" RADIX), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT (RADIX "inf"), 0, 0, 0.DL, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT ("nan(" RADIX ")"), 3, 3, DEC_NAN, 0, TEST_ALL},
+  {__LINE__, LOC_DE, INPUT ("nan(1,5)"), 3, 3, DEC_NAN, 0, TEST_ALL},
+
+  /* "inf" and "nan" are matched ignoring case, which must follow the C
+     locale's case mapping rather than the current locale's: tr_TR maps "I" to
+     U+0131 DOTLESS I, not to "i".  */
+  {__LINE__, LOC_TR, INPUT ("inf"), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("INF"), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("Inf"), 3, 3, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("+INFINITY"), 9, 9, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("iNfInItY"), 8, 8, DEC_INFINITY, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("nan"), 3, 3, DEC_NAN, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("NAN"), 3, 3, DEC_NAN, 0, TEST_ALL},
+  {__LINE__, LOC_TR, INPUT ("nan(I)"), 6, 6, DEC_NAN, 0, TEST_ALL},
+
+  /* U+0131 uppercases to "I" in tr_TR, but it is still not "i".  */
+  {__LINE__, LOC_TR, INPUT ("ınf"), 0, 0, 0.DL, 0, TEST_ALL},
+
   {0, NULL, NULL, 0, 0, 0, 0, 0, 0}
 };
 
@@ -193,7 +232,8 @@ check_int (int line, const char *what, int got, int expected)
 
 /* Convert IN with PFX ## tod ## WID and check the value, quantum exponent,
    sign and endptr.  WANT is in bytes for strtodN, wide characters for
-   wcstodN.  */
+   wcstodN.  A non-finite result has no quantum exponent, and the sign of a
+   NaN is not locale dependent, so both are only checked where they apply.  */
 #define RUN_ONE(pfx, ctype, wid, in, want, fmt)				      \
   do {									      \
     ctype *ep = NULL;							      \
@@ -201,10 +241,12 @@ check_int (int line, const char *what, int got, int expected)
     _Decimal ## wid res = pfx ## tod ## wid ((in), &ep);		      \
 									      \
     _VC_P (__FILE__, t->line, (_Decimal ## wid) t->expect, res, fmt);	      \
-    check_int (t->line, #pfx "tod" #wid " quantum exponent",		      \
-	       llquantexpd ## wid (res), t->qexp);			      \
-    check_int (t->line, #pfx "tod" #wid " sign", !!signbit (res),	      \
-	       !!signbit ((_Decimal ## wid) t->expect));		      \
+    if (isfinite (t->expect))						      \
+      check_int (t->line, #pfx "tod" #wid " quantum exponent",		      \
+		 llquantexpd ## wid (res), t->qexp);			      \
+    if (!isnan (t->expect))						      \
+      check_int (t->line, #pfx "tod" #wid " sign", !!signbit (res),	      \
+		 !!signbit ((_Decimal ## wid) t->expect));		      \
     check_int (t->line, #pfx "tod" #wid " endptr offset",		      \
 	       (int) (ep - (in)), (int) (want));			      \
     if (fail != fail0)							      \

--- a/tests/test-strtod-locale.c
+++ b/tests/test-strtod-locale.c
@@ -1,0 +1,270 @@
+/* Test the locale radix character handling of strtod[32|64|128] and
+   wcstod[32|64|128].
+
+   This file is part of the Decimal Floating Point C Library.
+
+   The Decimal Floating Point C Library is free software; you can
+   redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License version 2.1.
+
+   The Decimal Floating Point C Library is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+   the GNU Lesser General Public License version 2.1 for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License version 2.1 along with the Decimal Floating Point C Library;
+   if not, write to the Free Software Foundation, Inc., 51 Franklin
+   Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+   Please see libdfp/COPYING.txt for more information.  */
+
+/* strtodN() finds the radix character with nl_langinfo(RADIXCHAR) and matches
+   it against the input one byte at a time, whereas wcstodN() matches the
+   single wide character from _NL_NUMERIC_DECIMAL_POINT_WC.  Those byte-wise
+   comparisons, and the pointer adjustments which step over the radix
+   character, are only observable in a locale whose radix character is longer
+   than one byte.
+
+   test-strtod.c already covers parsing, rounding, errno and endptr in the C
+   locale.  This test adds only inputs whose outcome depends on the radix
+   character, one per distinct path through the parser, run in a locale whose
+   radix character is "." (C), a single byte which is not "." (de_DE), and a
+   multibyte UTF-8 sequence (ps_AF).  */
+
+#ifndef __STDC_WANT_DEC_FP__
+# define __STDC_WANT_DEC_FP__ 1
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include <math.h>
+#include <locale.h>
+#include <langinfo.h>
+
+#define _WANT_VC 1
+
+#include "scaffold.c"
+
+/* U+066B ARABIC DECIMAL SEPARATOR, the radix character of the ps_AF locale.
+   It occupies two bytes, 0xd9 0xab, in UTF-8.  */
+#define RADIX	"٫"
+/* Its leading byte on its own.  That is not a valid multibyte character, so
+   an input containing it has no wide-character form.  */
+#define RADIX_HI "\xd9"
+
+/* Give both the multibyte and the wide-character form of an input.  The empty
+   wide literal widens the concatenation without needing the input to be a
+   single token, so that RADIX may appear anywhere in it.  */
+#define INPUT(s)	s, L"" s
+/* ... for an input which is not a valid multibyte string.  */
+#define INPUT_MB(s)	s, NULL
+
+#define LOC_C	"C"
+#define LOC_DE	"de_DE.UTF-8"
+#define LOC_PS	"ps_AF.UTF-8"
+
+typedef enum {
+  TEST_D32 = 1 << 0,
+  TEST_D64 = 1 << 1,
+  TEST_D128 = 1 << 2,
+#define TEST_ALL (TEST_D32 | TEST_D64 | TEST_D128)
+} test_type_flags;
+
+typedef struct {
+  int line;
+  const char *locale;	/* Installed with setlocale (LC_ALL, ...).  */
+  const char *input;
+  const wchar_t *winput;	/* NULL if there is no wide-character form.  */
+  size_t nbytes;	/* Bytes strtodN is expected to consume.  */
+  size_t nwchars;	/* Wide characters wcstodN is expected to consume.  */
+  _Decimal128 expect;	/* Expected value.  Unless an entry is restricted to a
+			   single width it is exactly representable as a
+			   _Decimal32, so all three widths share it.  */
+  int qexp;		/* Expected quantum exponent.  */
+  test_type_flags types;
+} strtod_locale_test;
+
+strtod_locale_test tests[] =
+{
+  /* The C locale, for reference: "." is the radix character, and U+066B is
+     just a character (a pair of stray bytes, for strtodN) which ends the
+     number.  */
+  {__LINE__, LOC_C, INPUT ("1.25"), 4, 4, 1.25DL, -2, TEST_ALL},
+  {__LINE__, LOC_C, INPUT ("1" RADIX "25"), 1, 1, 1.DL, 0, TEST_ALL},
+
+  /* A single-byte radix character which is not ".".  */
+  {__LINE__, LOC_DE, INPUT ("1,25"), 4, 4, 1.25DL, -2, TEST_ALL},
+  {__LINE__, LOC_DE, INPUT ("1.25"), 1, 1, 1.DL, 0, TEST_ALL},
+
+  /* A multibyte radix character.  Integer digits, radix, fractional digits:
+     the radix is matched after the integer part, and is later stepped over in
+     the middle of the coefficient by the digit accumulation loop.  */
+  {__LINE__, LOC_PS, INPUT ("1" RADIX "25"), 5, 4, 1.25DL, -2, TEST_ALL},
+
+  /* A leading radix character is accepted only when a digit follows it, which
+     is decided by looking decimal_len bytes ahead before any digit has been
+     read ...  */
+  {__LINE__, LOC_PS, INPUT (RADIX "25"), 4, 3, 0.25DL, -2, TEST_ALL},
+  /* ... and otherwise no conversion is performed, which must leave endptr at
+     the start of the string rather than after the radix character.  */
+  {__LINE__, LOC_PS, INPUT (RADIX "e5"), 0, 0, 0.DL, 0, TEST_ALL},
+
+  /* A trailing radix character with no fractional digits ("american style"):
+     endptr has to advance over the whole radix character.  */
+  {__LINE__, LOC_PS, INPUT ("12" RADIX), 4, 3, 12.DL, 0, TEST_ALL},
+
+  /* No integer digits and a zero fraction.  The parser rescans the string for
+     the radix character to find the first significant digit; check the sign
+     of the resulting zero while here.  */
+  {__LINE__, LOC_PS, INPUT ("-" RADIX "0"), 4, 3, -0.0DL, -1, TEST_ALL},
+
+  /* The same rescan with leading fractional zeroes, which places the start of
+     the coefficient at radix position + leading zeroes + decimal_len; a wrong
+     length shifts the coefficient.  The number of significant digits is
+     exactly _Decimal32's precision, so no rounding is involved.  */
+  {__LINE__, LOC_PS, INPUT ("0" RADIX "001234567"), 12, 11, 1.234567E-3DL, -9,
+   TEST_ALL},
+
+  /* Radix character directly followed by an exponent.  */
+  {__LINE__, LOC_PS, INPUT ("1" RADIX "5e2"), 6, 5, 1.5E2DL, 1, TEST_ALL},
+
+  /* A second radix character ends the number, with endptr on its first byte.  */
+  {__LINE__, LOC_PS, INPUT ("1" RADIX "2" RADIX "3"), 4, 3, 1.2DL, -1, TEST_ALL},
+
+  /* "." is an ordinary character here, and ends the number.  */
+  {__LINE__, LOC_PS, INPUT ("1.25"), 1, 1, 1.DL, 0, TEST_ALL},
+
+  /* The digit accumulation loop steps over the radix character by testing
+     each byte for "not a digit", and must do so without disturbing the count
+     of digits read.  Placing the radix character exactly at _Decimal32's
+     precision boundary makes that skip happen between the last coefficient
+     digit and the rounding digit.  The wider formats hold the value
+     exactly.  */
+  {__LINE__, LOC_PS, INPUT ("1234567" RADIX "89"), 11, 10, 1234568.DL, 0,
+   TEST_D32},
+  {__LINE__, LOC_PS, INPUT ("1234567" RADIX "89"), 11, 10, 1234567.89DL, -2,
+   TEST_D64 | TEST_D128},
+
+  /* A fragment of the radix character must never match it.  These reach the
+     three separate byte-wise comparisons: after the integer digits, after the
+     leading zeroes (where the comparison also has to stop at the terminating
+     NUL instead of reading past it), and before any digit has been seen.  */
+  {__LINE__, LOC_PS, INPUT_MB ("1" RADIX_HI "25"), 1, 0, 1.DL, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT_MB ("0" RADIX_HI), 1, 0, 0.DL, 0, TEST_ALL},
+  {__LINE__, LOC_PS, INPUT_MB (RADIX_HI "25"), 0, 0, 0.DL, 0, TEST_ALL},
+
+  {0, NULL, NULL, 0, 0, 0, 0, 0, 0}
+};
+
+/* Render S into OUT with everything but printable ASCII escaped, so that
+   failure messages stay readable whatever the input encoding is.  */
+static const char *
+quote (char *out, size_t outlen, const char *s)
+{
+  size_t o = 0;
+
+  for (; *s != '\0' && o + 5 < outlen; ++s)
+    {
+      unsigned char c = (unsigned char) *s;
+
+      if (c >= 0x20 && c < 0x7f)
+	out[o++] = (char) c;
+      else
+	o += sprintf (out + o, "\\x%02x", c);
+    }
+  out[o] = '\0';
+  return out;
+}
+
+static void
+check_int (int line, const char *what, int got, int expected)
+{
+  if (got != expected)
+    {
+      fprintf (stdout, "%-3d Error: %s is %d, expected %d\n",
+	       testnum, what, got, expected);
+      fprintf (stdout, "in: %s:%d.\n\n", __FILE__, line);
+      ++fail;
+    }
+}
+
+/* Convert IN with PFX ## tod ## WID and check the value, quantum exponent,
+   sign and endptr.  WANT is in bytes for strtodN, wide characters for
+   wcstodN.  */
+#define RUN_ONE(pfx, ctype, wid, in, want, fmt)				      \
+  do {									      \
+    ctype *ep = NULL;							      \
+    int fail0 = fail;							      \
+    _Decimal ## wid res = pfx ## tod ## wid ((in), &ep);		      \
+									      \
+    _VC_P (__FILE__, t->line, (_Decimal ## wid) t->expect, res, fmt);	      \
+    check_int (t->line, #pfx "tod" #wid " quantum exponent",		      \
+	       llquantexpd ## wid (res), t->qexp);			      \
+    check_int (t->line, #pfx "tod" #wid " sign", !!signbit (res),	      \
+	       !!signbit ((_Decimal ## wid) t->expect));		      \
+    check_int (t->line, #pfx "tod" #wid " endptr offset",		      \
+	       (int) (ep - (in)), (int) (want));			      \
+    if (fail != fail0)							      \
+      fprintf (stdout, "    locale \"%s\", input \"%s\"\n\n",		      \
+	       t->locale, printable);					      \
+  } while (0)
+
+#define RUN_WIDTH(wid, fmt)						      \
+  do {									      \
+    if (t->types & TEST_D ## wid)					      \
+      {									      \
+	RUN_ONE (str, char, wid, t->input, t->nbytes, fmt);		      \
+	if (t->winput != NULL)						      \
+	  RUN_ONE (wcs, wchar_t, wid, t->winput, t->nwchars, fmt);	      \
+      }									      \
+  } while (0)
+
+static void
+run_test (const strtod_locale_test *t)
+{
+  char quoted[256];
+  const char *printable = quote (quoted, sizeof (quoted), t->input);
+
+  if (verbose)
+    fprintf (stdout, "%s: \"%s\"\n", t->locale, printable);
+
+  RUN_WIDTH (32, "%.6He");
+  RUN_WIDTH (64, "%.15De");
+  RUN_WIDTH (128, "%.33DDe");
+}
+
+int
+main (int argc, char *argv[])
+{
+  const strtod_locale_test *t;
+
+  verbose = 0; /* Make passing results quiet by default.  */
+
+  for (int i = 1; i < argc; i++)
+    if (strcmp (argv[i], "-v") == 0 || strcmp (argv[i], "--verbose") == 0)
+      verbose = 1;
+
+  for (t = tests; t->input != NULL; t++)
+    {
+      if (setlocale (LC_ALL, t->locale) == NULL)
+	{
+	  /* A locale which is not installed is warned about and skipped
+	      rather than failed.  */
+	  fprintf (stderr, "Warning: locale \"%s\" is not installed, "
+		   "its tests did not run.\n", t->locale);
+	  continue;
+	}
+
+      run_test (t);
+    }
+
+  setlocale (LC_ALL, "C");
+
+  _REPORT ();
+
+  /* fail comes from scaffold.c  */
+  return fail;
+}

--- a/tests/test-strtod.c
+++ b/tests/test-strtod.c
@@ -39,6 +39,9 @@
 
 #include "scaffold.c"
 
+#include <errno.h>
+#include <float.h>
+
 /* Inspired by GLIBC stdio-common/tfformat.c  */
 typedef struct{
   int line;
@@ -96,6 +99,138 @@ d_type strtods[] =
   {__LINE__, "1X123", 1.DF, 0, 1.DD, 0, 1.DL, 0, 4},
   {__LINE__, "10x123", 10.DF, 0, 10.DD, 0, 10.DL, 0, 4},
   {__LINE__, "10X123", 10.DF, 0, 10.DD, 0, 10.DL, 0, 4},
+
+  /* Whitespace handling edge cases */
+  {__LINE__, "   123.45", 123.45DF, -2, 123.45DD, -2, 123.45DL, -2, 0},
+  {__LINE__, "\t\t123.45", 123.45DF, -2, 123.45DD, -2, 123.45DL, -2, 0},
+  {__LINE__, "\n123.45", 123.45DF, -2, 123.45DD, -2, 123.45DL, -2, 0},
+  {__LINE__, " \t\n\r123.45", 123.45DF, -2, 123.45DD, -2, 123.45DL, -2, 0},
+
+  /* Sign edge cases */
+  {__LINE__, "+123.45", 123.45DF, -2, 123.45DD, -2, 123.45DL, -2, 0},
+  {__LINE__, "+0.0", 0.0DF, -1, 0.0DD, -1, 0.0DL, -1, 0},
+  {__LINE__, "-0.0", -0.0DF, -1, -0.0DD, -1, -0.0DL, -1, 0},
+  {__LINE__, "+inf", DEC_INFINITY, 0, DEC_INFINITY, 0, DEC_INFINITY, 0, 0},
+  {__LINE__, "-inf", -DEC_INFINITY, 0, -DEC_INFINITY, 0, -DEC_INFINITY, 0, 0},
+
+  /* Empty and invalid input */
+  {__LINE__, "", 0.DF, 0, 0.DD, 0, 0.DL, 0, 0},
+  {__LINE__, "   ", 0.DF, 0, 0.DD, 0, 0.DL, 0, 3},
+  {__LINE__, ".", 0.DF, 0, 0.DD, 0, 0.DL, 0, 1},
+  {__LINE__, "+", 0.DF, 0, 0.DD, 0, 0.DL, 0, 1},
+  {__LINE__, "-", 0.DF, 0, 0.DD, 0, 0.DL, 0, 1},
+
+  /* Special value variations */
+  {__LINE__, "INF", DEC_INFINITY, 0, DEC_INFINITY, 0, DEC_INFINITY, 0, 0},
+  {__LINE__, "Inf", DEC_INFINITY, 0, DEC_INFINITY, 0, DEC_INFINITY, 0, 0},
+  {__LINE__, "infinity", DEC_INFINITY, 0, DEC_INFINITY, 0, DEC_INFINITY, 0, 0},
+  {__LINE__, "Infinity", DEC_INFINITY, 0, DEC_INFINITY, 0, DEC_INFINITY, 0, 0},
+  {__LINE__, "+INFINITY", DEC_INFINITY, 0, DEC_INFINITY, 0, DEC_INFINITY, 0, 0},
+  {__LINE__, "-INFINITY", -DEC_INFINITY, 0, -DEC_INFINITY, 0, -DEC_INFINITY, 0, 0},
+  {__LINE__, "nan", DEC_NAN, 0, DEC_NAN, 0, DEC_NAN, 0, 0},
+  {__LINE__, "NAN", DEC_NAN, 0, DEC_NAN, 0, DEC_NAN, 0, 0},
+  {__LINE__, "NaN", DEC_NAN, 0, DEC_NAN, 0, DEC_NAN, 0, 0},
+  {__LINE__, "+nan", DEC_NAN, 0, DEC_NAN, 0, DEC_NAN, 0, 0},
+  {__LINE__, "-nan", DEC_NAN, 0, DEC_NAN, 0, DEC_NAN, 0, 0},
+
+  /* Precision boundary tests - _Decimal32 has 7 significant digits */
+  {__LINE__, "1234567", 1234567.DF, 0, 1234567.DD, 0, 1234567.DL, 0, 0},
+  {__LINE__, "12345678", 1.234568E7DF, 1, 12345678.DD, 0, 12345678.DL, 0, 0},
+  {__LINE__, "1.234567", 1.234567DF, -6, 1.234567DD, -6, 1.234567DL, -6, 0},
+  {__LINE__, "1.2345678", 1.234568DF, -6, 1.2345678DD, -7, 1.2345678DL, -7, 0},
+  {__LINE__, "0.1234567", 0.1234567DF, -7, 0.1234567DD, -7, 0.1234567DL, -7, 0},
+
+  /* _Decimal64 precision tests - 16 significant digits */
+  {__LINE__, "1234567890123456", 1234567890123456.DF, 9, 1234567890123456.DD, 0, 1234567890123456.DL, 0, 0},
+  {__LINE__, "1.234567890123456", 1.234568DF, -6, 1.234567890123456DD, -15, 1.234567890123456DL, -15, 0},
+
+  /* _Decimal128 precision tests - 34 significant digits */
+  {__LINE__, "1234567890123456789012345678901234", 1.234568E33DF, 27,
+   1.234567890123457E33DD, 18, 1234567890123456789012345678901234.DL, 0, 0},
+
+  /* Exponent variations */
+  {__LINE__, "1.5e10", 1.5E10DF, 9, 1.5E10DD, 9, 1.5E10DL, 9, 0},
+  {__LINE__, "1.5E10", 1.5E10DF, 9, 1.5E10DD, 9, 1.5E10DL, 9, 0},
+  {__LINE__, "1.5e+10", 1.5E10DF, 9, 1.5E10DD, 9, 1.5E10DL, 9, 0},
+  {__LINE__, "1.5e-10", 1.5E-10DF, -11, 1.5E-10DD, -11, 1.5E-10DL, -11, 0},
+  {__LINE__, "1.5e0", 1.5DF, -1, 1.5DD, -1, 1.5DL, -1, 0},
+  {__LINE__, "1.5e00", 1.5DF, -1, 1.5DD, -1, 1.5DL, -1, 0},
+  {__LINE__, "1.5e+00000010", 1.5E10DF, 9, 1.5E10DD, 9, 1.5E10DL, 9, 0},
+
+  /* Leading zeros */
+  {__LINE__, "0000123", 123.DF, 0, 123.DD, 0, 123.DL, 0, 0},
+  {__LINE__, "0000123.456", 123.456DF, -3, 123.456DD, -3, 123.456DL, -3, 0},
+  {__LINE__, "0.000123", 0.000123DF, -6, 0.000123DD, -6, 0.000123DL, -6, 0},
+  {__LINE__, "00000.000000", 0.0DF, -6, 0.0DD, -6, 0.0DL, -6, 0},
+  {__LINE__, "0000000", 0.DF, 0, 0.DD, 0, 0.DL, 0, 0},
+
+  /* Trailing zeros (important for decimal types - they preserve trailing zeros) */
+  {__LINE__, "123.000", 123.000DF, -3, 123.000DD, -3, 123.000DL, -3, 0},
+  {__LINE__, "123.4560000", 123.4560DF, -4, 123.4560000DD, -7, 123.4560000DL, -7, 0},
+  {__LINE__, "0.10000", 0.10000DF, -5, 0.10000DD, -5, 0.10000DL, -5, 0},
+
+  /* Minimum normal values */
+  {__LINE__, "1E-95", 1E-95DF, -95, 1E-95DD, -95, 1E-95DL, -95, 0},
+  {__LINE__, "1E-383", 0.DF, 0, 1E-383DD, -383, 1E-383DL, -383, 0},
+  {__LINE__, "1E-6143", 0.DF, 0, 0.DD, 0, 1E-6143DL, -6143, 0},
+
+  /* Subnormal values */
+  {__LINE__, "1E-96", 1E-96DF, -96, 1E-96DD, -96, 1E-96DL, -96, 0},
+  {__LINE__, "1E-101", 1E-101DF, -101, 1E-101DD, -101, 1E-101DL, -101, 0},
+  {__LINE__, "1E-384", 0.DF, 0, 1E-384DD, -384, 1E-384DL, -384, 0},
+  {__LINE__, "1E-398", 0.DF, 0, 1E-398DD, -398, 1E-398DL, -398, 0},
+  {__LINE__, "1E-6144", 0.DF, 0, 0.DD, 0, 1E-6144DL, -6144, 0},
+  {__LINE__, "1E-6176", 0.DF, 0, 0.DD, 0, 1E-6176DL, -6176, 0},
+
+  /* Values near limits */
+  {__LINE__, "9.999999E96", 9.999999E96DF, 90, 9.999999E96DD, 90, 9.999999E96DL, 90, 0},
+  {__LINE__, "9.999999999999999E384", DEC_INFINITY, 0, 9.999999999999999E384DD, 369, 9.999999999999999E384DL, 369, 0},
+
+  /* Decimal point edge cases */
+  {__LINE__, "123.", 123.DF, 0, 123.DD, 0, 123.DL, 0, 0},
+  {__LINE__, ".123", 0.123DF, -3, 0.123DD, -3, 0.123DL, -3, 0},
+  {__LINE__, ".0", 0.0DF, -1, 0.0DD, -1, 0.0DL, -1, 0},
+
+  /* Very long mantissa */
+  {__LINE__, "1.234567890123456789012345678901234567890", 1.234568DF, -6, 1.234567890123457DD, -15,
+              1.234567890123456789012345678901235DL, -33, 0},
+
+  /* Numbers with many fractional zeros */
+  {__LINE__, "0.00000000000000000000000000000001", 1E-32DF, -32, 1E-32DD, -32, 1E-32DL, -32, 0},
+
+  /* --- Format limits and coefficient clamping ---
+     When the written exponent exceeds Qmax (= Emax - (precision - 1)) but the
+     value still fits, the coefficient is padded with trailing zeros and the
+     exponent is clamped down to Qmax.  For _Decimal32 Qmax = 96 - 6 = 90; for
+     _Decimal64 Qmax = 384 - 15 = 369; for _Decimal128 Qmax = 6144 - 33 = 6111. */
+  {__LINE__, "1E96", 1E96DF, 90, 1E96DD, 96, 1E96DL, 96, 0},
+  {__LINE__, "1E369", DEC_INFINITY, 0, 1E369DD, 369, 1E369DL, 369, 0},
+  {__LINE__, "1E384", DEC_INFINITY, 0, 1E384DD, 369, 1E384DL, 384, 0},
+  {__LINE__, "1E6111", DEC_INFINITY, 0, DEC_INFINITY, 0, 1E6111DL, 6111, 0},
+  {__LINE__, "1E6144", DEC_INFINITY, 0, DEC_INFINITY, 0, 1E6144DL, 6111, 0},
+
+  /* Largest finite magnitude for each type, written with a full-length
+     coefficient.  One ULP more in the coefficient overflows to infinity. */
+  {__LINE__, "9999999E90", 9.999999E96DF, 90, 9.999999E96DD, 90, 9.999999E96DL, 90, 0},
+
+  /* Round-half-even exactly at the precision boundary: the guard digit is 5
+     with no following nonzero digits, so the tie breaks toward the even digit. */
+  {__LINE__, "1.2345675", 1.234568DF, -6, 1.2345675DD, -7, 1.2345675DL, -7, 0}, /* 7 is odd -> round up */
+  {__LINE__, "1.2345665", 1.234566DF, -6, 1.2345665DD, -7, 1.2345665DL, -7, 0}, /* 6 is even -> stay */
+  {__LINE__, "1.2345655", 1.234566DF, -6, 1.2345655DD, -7, 1.2345655DL, -7, 0}, /* 5 is odd -> round up */
+
+  /* Rounding that carries across a power of ten.  For _Decimal32 the carry
+     (9999999|5 -> 1.000000E97) pushes the value past the maximum finite
+     exponent and should overflow to +infinity.
+     KNOWN BUG: strtod32() returns NaN here (and sets no errno) instead of
+     overflowing; the coefficient carry into an 8th digit is mishandled. */
+  {__LINE__, "9.9999995E96", DEC_INFINITY, 0, 9.9999995E96DD, 89, 9.9999995E96DL, 89, 0},
+
+  /* Guard digit 5 followed by more nonzero digits must round up (sticky bit).
+     KNOWN BUG: the fractional reader keeps only one guard digit with no sticky
+     bit, so _Decimal32 rounds 1.2345665|0001 to 1.234566 instead of 1.234567. */
+  {__LINE__, "1.23456650001", 1.234567DF, -6, 1.23456650001DD, -11, 1.23456650001DL, -11, 0},
+
   {0,0,0,0,0,0,0,0,0 }
 };
 
@@ -106,6 +241,16 @@ const char DECLET128_NAN[] = "+0,000,000,000,000,000,000,000,000,000,000,000E-61
 const char DECLET_ZERO_D32[] = "+0,000,000E+0";
 const char DECLET_ZERO_D64[] = "+0,000,000,000,000,000E+0";
 
+/* WARNING: these are byte-for-byte identical to the DECLET*_NAN strings above,
+   and that is not a coincidence.  decoded32/64/128() (sysdeps/bid/decode.c)
+   bail out for *any* special-encoded value, leaving coeff=0 and exp=-Bias, so
+   infinity and NaN both decode to "+0,...,000E-<Bias>" (only the sign differs).
+   Consequently a _DC_P comparison against these constants CANNOT distinguish
+   overflow-to-infinity from NaN (nor from a genuine min-exponent zero) -- an
+   overflow declet test here would pass even if strtod erroneously returned NaN.
+   Real "overflow returns +/-infinity" verification must use the value-compare
+   (_VC_P, x==y vs DEC_INFINITY) entries in strtods[] and the errno tests; those
+   are what actually catch the overflow-carry->NaN divergence.  */
 const char DECLET_HUGE_VAL_D32[] = "+0,000,000E-101";
 const char DECLET_HUGE_VAL_D64[] = "+0,000,000,000,000,000E-398";
 const char DECLET_HUGE_VAL_D128[] = "+0,000,000,000,000,000,000,000,000,000,000,000E-6176";
@@ -126,16 +271,13 @@ d_nan_type strtods_nan[] =
   {__LINE__, "NaN", DECLET32_NAN, DECLET64_NAN, DECLET128_NAN},
   {__LINE__, "4E-382", "+0,000,000E+0", "+0,000,000,000,000,004E-382", "+0,000,000,000,000,000,000,000,000,000,000,004E-382"},
 
-  /* __DEC64_SUBNORMAL_MIN__ */
   {__LINE__, "0.000000000000001E-383",  DECLET_ZERO_D32, "+0,000,000,000,000,001E-398", "+0,000,000,000,000,000,000,000,000,000,000,001E-398"},
-  /* This exceeds __DEC64_MIN_EXP__ so it can't be encoded in _Decimal64 and will underflow.  */
-  {__LINE__, "4E-399", DECLET_ZERO_D32, "+0,000,000,000,000,000E+0", "+0,000,000,000,000,000,000,000,000,000,000,004E-399"},
+  {__LINE__, "4E-399", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,004E-399"},
   {__LINE__, "4000000000000000E-383", DECLET_ZERO_D32, "+4,000,000,000,000,000E-383", "+0,000,000,000,000,000,004,000,000,000,000,000E-383"},
   {__LINE__, "4000000000000000E-384", DECLET_ZERO_D32, "+4,000,000,000,000,000E-384", "+0,000,000,000,000,000,004,000,000,000,000,000E-384"},
   {__LINE__, "4000000000000000E-398", DECLET_ZERO_D32, "+4,000,000,000,000,000E-398", "+0,000,000,000,000,000,004,000,000,000,000,000E-398"},
-  /* This exceeds __DEC64_MIN_EXP__ so it can't be encoded in _Decimal64 and will underflow.  */
-  {__LINE__, "4000000000000000E-399", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,004,000,000,000,000,000E-399"},
-  /* This exceeds __DEC64_SUBNORMAL_MIN__ so it can't be encoded in _Decimal64 and will underflow.  */
+  {__LINE__, "4E-398", DECLET_ZERO_D32, "+0,000,000,000,000,004E-398", "+0,000,000,000,000,000,000,000,000,000,000,004E-398"},
+  {__LINE__, "4E-399", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,004E-399"},
   {__LINE__, "4E-400", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,004E-400"},
 
   {__LINE__, "4E369", DECLET_HUGE_VAL_D32, "+0,000,000,000,000,004E+369", "+0,000,000,000,000,000,000,000,000,000,000,004E+369"},
@@ -147,7 +289,202 @@ d_nan_type strtods_nan[] =
 
   {__LINE__, "1.23456789E-7", "+1,234,568E-13", "+0,000,000,123,456,789E-15", "+0,000,000,000,000,000,000,000,000,123,456,789E-15" },
   {__LINE__, "1234.5678910111213e-5", "+1,234,568E-8", "+1,234,567,891,011,121E-17", "+0,000,000,000,000,000,012,345,678,910,111,213E-18" },
+
+  /* Coefficient clamping.  "1E96" needs exponent 96, but _Decimal32's largest
+     quantum exponent is 90, so the coefficient is padded to 1000000E90.  For
+     _Decimal64 and _Decimal128 the exponent fits and the coefficient stays 1. */
+  {__LINE__, "1E96", "+1,000,000E+90", "+0,000,000,000,000,001E+96", "+0,000,000,000,000,000,000,000,000,000,000,001E+96" },
+
+  /* Largest finite magnitude, exact coefficient/exponent for each type. */
+  {__LINE__, "9999999E90", "+9,999,999E+90", "+0,000,000,009,999,999E+90", "+0,000,000,000,000,000,000,000,000,009,999,999E+90" },
+
+  /* Exact fraction with trailing zeros preserves the written quantum. */
+  {__LINE__, "1.2500", "+0,012,500E-4", "+0,000,000,000,012,500E-4", "+0,000,000,000,000,000,000,000,000,000,012,500E-4" },
+
+  /* Subnormal rounding for _Decimal32: the smallest quantum is -101, so
+     1.5E-101 cannot be represented exactly and should round half-to-even to
+     2E-101.  For _Decimal64/_Decimal128 the value is normal and exact.
+     KNOWN BUG: strtod32() flushes 1.5E-101 to zero because the pre-rounding
+     underflow check rejects exponent -102 without considering that rounding
+     brings the value into the representable subnormal range. */
+  {__LINE__, "1.5E-101", "+0,000,002E-101", "+0,000,000,000,000,015E-102", "+0,000,000,000,000,000,000,000,000,000,000,015E-102" },
+
+  /* Half-to-even underflow: 0.5E-101 is exactly half the smallest _Decimal32
+     subnormal and correctly rounds to +0.  For _Decimal64/_Decimal128 it is a
+     normal, exact value. */
+  {__LINE__, "0.5E-101", "+0,000,000E+0", "+0,000,000,000,000,005E-102", "+0,000,000,000,000,000,000,000,000,000,000,005E-102" },
+
+  /* More _Decimal32 subnormal roundings, probing both directions and a tie.
+     All have written exponent -102 (one below Qmin) and should round to a
+     nonzero subnormal; the D64/D128 values are normal and exact.
+     KNOWN BUG: strtod32() flushes every one of these to zero. */
+  {__LINE__, "1.4E-101", "+0,000,001E-101", "+0,000,000,000,000,014E-102", "+0,000,000,000,000,000,000,000,000,000,000,014E-102" }, /* down -> 1E-101 */
+  {__LINE__, "1.6E-101", "+0,000,002E-101", "+0,000,000,000,000,016E-102", "+0,000,000,000,000,000,000,000,000,000,000,016E-102" }, /* up   -> 2E-101 */
+  {__LINE__, "2.5E-101", "+0,000,002E-101", "+0,000,000,000,000,025E-102", "+0,000,000,000,000,000,000,000,000,000,000,025E-102" }, /* tie  -> 2E-101 */
+
+  /* The subnormal-rounding flaw is not specific to _Decimal32.  6E-399 rounds
+     UP into the _Decimal64 subnormal range (-> 1E-398), unlike the neighbouring
+     4E-399 above which correctly rounds DOWN to +0.  The D64 field is the buggy
+     one here: it is flushed to zero instead of rounding to 1E-398. */
+  {__LINE__, "6E-399", DECLET_ZERO_D32, "+0,000,000,000,000,001E-398", "+0,000,000,000,000,000,000,000,000,000,000,006E-399" }, /* D64 -> 1E-398 */
+  {__LINE__, "1.5E-398", DECLET_ZERO_D32, "+0,000,000,000,000,002E-398", "+0,000,000,000,000,000,000,000,000,000,000,015E-399" }, /* D64 -> 2E-398 */
+
+  /* Same flaw at the _Decimal128 subnormal boundary.  The D128 field is buggy. */
+  {__LINE__, "6E-6177", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,001E-6176" }, /* D128 -> 1E-6176 */
+  {__LINE__, "1.5E-6176", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,002E-6176" }, /* D128 -> 2E-6176 */
   {0,0,0,0,0 }
+};
+
+typedef enum {
+  TEST_D32 = 1 << 0,
+  TEST_D64 = 1 << 1,
+  TEST_D128 = 1 << 2,
+#define TEST_ALL (TEST_D32 | TEST_D64 | TEST_D128)
+#define _TEST_TYPE_CNT 3
+} test_type_flags;
+
+typedef struct {
+  int line;
+  const char *input;
+  int expected_errno;
+  test_type_flags types;
+  const char *description;
+} errno_test;
+
+errno_test overflow_errno_tests[] = {
+  /* Overflow should set errno to ERANGE */
+  {__LINE__, "1E97", ERANGE, TEST_D32, "D32 overflow"},
+  {__LINE__, "1E100", ERANGE, TEST_D32, "D32 large overflow"},
+  {__LINE__, "9.999999E97", ERANGE, TEST_D32, "D32 overflow with full mantissa"},
+  {__LINE__, "-1E97", ERANGE, TEST_D32, "D32 negative overflow"},
+  {__LINE__, "1E385", ERANGE, TEST_D64, "D64 overflow"},
+  {__LINE__, "1E400", ERANGE, TEST_D64, "D64 large overflow"},
+  {__LINE__, "-1E385", ERANGE, TEST_D64, "D64 negative overflow"},
+  {__LINE__, "1E6145", ERANGE, TEST_D128, "D128 overflow"},
+  {__LINE__, "1E10000", ERANGE, TEST_D128, "D128 large overflow"},
+  {__LINE__, "-1E6145", ERANGE, TEST_D128, "D128 negative overflow"},
+  {__LINE__, "9.999999E99999", ERANGE, TEST_ALL, "Extreme overflow"},
+
+  /* Boundary: the largest finite magnitude must NOT set errno. */
+  {__LINE__, "9.999999E96", 0, TEST_D32, "D32 largest finite is not overflow"},
+  {__LINE__, "9.999999999999999E384", 0, TEST_D64, "D64 largest finite is not overflow"},
+
+  /* Boundary: the smallest representable overflow (one ULP into infinity). */
+  {__LINE__, "1.000000E97", ERANGE, TEST_D32, "D32 smallest overflow"},
+  {__LINE__, "1.000000000000000E385", ERANGE, TEST_D64, "D64 smallest overflow"},
+
+  /* Rounding of a full-precision coefficient carries past Emax and should
+     overflow.  KNOWN BUG: strtodN() returns NaN and sets no errno instead of
+     overflowing to infinity when the rounding carry adds a significant digit. */
+  {__LINE__, "9.9999995E96", ERANGE, TEST_D32, "D32 overflow produced by rounding carry"},
+  {__LINE__, "9.9999999999999995E384", ERANGE, TEST_D64, "D64 overflow produced by rounding carry"},
+  {__LINE__, "9.9999999999999999999999999999999995E6144", ERANGE, TEST_D128, "D128 overflow produced by rounding carry"},
+
+  /* A very long exponent field must be handled without integer overflow. */
+  {__LINE__, "1E999999999999999999999", ERANGE, TEST_ALL, "Exponent field far beyond int range"},
+  {0, NULL, 0, 0, NULL},
+
+  /* Underflow to zero should set errno to ERANGE */
+  {__LINE__, "1E-102", ERANGE, TEST_D32, "D32 underflow"},
+  {__LINE__, "1E-200", ERANGE, TEST_D32, "D32 large underflow"},
+  {__LINE__, "-1E-102", ERANGE, TEST_D32, "D32 negative underflow"},
+  {__LINE__, "1E-399", ERANGE, TEST_D64, "D64 underflow"},
+  {__LINE__, "1E-500", ERANGE, TEST_D64, "D64 large underflow"},
+  {__LINE__, "-1E-399", ERANGE, TEST_D64, "D64 negative underflow"},
+  {__LINE__, "1E-6177", ERANGE, TEST_D128, "D128 underflow"},
+  {__LINE__, "1E-10000", ERANGE, TEST_D128, "D128 large underflow"},
+  {__LINE__, "-1E-6177", ERANGE, TEST_D128, "D128 negative underflow"},
+  {__LINE__, "0.0e100000", 0, TEST_ALL, "Zero should not set errno"},
+  {__LINE__, "0.0e-100000", 0, TEST_ALL, "Zero with large negative exponent should not set errno"},
+
+  /* Boundary: the smallest subnormal must NOT set errno (it is representable). */
+  {__LINE__, "1E-101", 0, TEST_D32, "D32 smallest subnormal is not underflow"},
+  {__LINE__, "1E-398", 0, TEST_D64, "D64 smallest subnormal is not underflow"},
+  {__LINE__, "1E-6176", 0, TEST_D128, "D128 smallest subnormal is not underflow"},
+
+  /* A very long negative exponent field must underflow without integer overflow. */
+  {__LINE__, "1E-999999999999999999999", ERANGE, TEST_ALL, "Exponent field far below int range"},
+  {0, NULL, 0, 0, NULL}
+};
+
+typedef struct {
+  int line;
+  const char *input;
+  size_t expected_chars_parsed;
+  test_type_flags types;
+  const char *description;
+} endptr_test;
+
+endptr_test endptr_tests[] = {
+  {__LINE__, "123abc", 3, TEST_ALL, "Number followed by letters"},
+  {__LINE__, "123.45xyz", 6, TEST_ALL, "Decimal followed by letters"},
+  {__LINE__, "123e10abc", 6, TEST_ALL, "Exponent followed by letters"},
+  {__LINE__, "  123  ", 5, TEST_ALL, "Whitespace on both sides"},
+  {__LINE__, "inf!", 3, TEST_ALL, "Infinity followed by character"},
+  {__LINE__, "INFINITY!", 8, TEST_ALL, "INFINITY followed by character"},
+  {__LINE__, "nan(123)extra", 8, TEST_ALL, "NaN with payload followed by text"},
+  {__LINE__, "123,456", 3, TEST_ALL, "Comma is not valid (C locale)"},
+  {__LINE__, "1.23.45", 4, TEST_ALL, "Second decimal point stops parsing"},
+  {__LINE__, "1e2e3", 3, TEST_ALL, "Second exponent stops parsing"},
+  {__LINE__, "++123", 0, TEST_ALL, "Invalid double sign"},
+  {__LINE__, "--123", 0, TEST_ALL, "Invalid double negative"},
+  {__LINE__, "+-123", 0, TEST_ALL, "Invalid mixed signs"},
+  {__LINE__, "123e", 3, TEST_ALL, "Incomplete exponent"},
+  {__LINE__, "123e+", 3, TEST_ALL, "Incomplete exponent with sign"},
+  {__LINE__, "123e-", 3, TEST_ALL, "Incomplete exponent with negative sign"},
+  {__LINE__, ".e5", 0, TEST_ALL, "Decimal point with exponent"},
+  {__LINE__, "e10", 0, TEST_ALL, "Just exponent"},
+  {__LINE__, "", 0, TEST_ALL, "Empty string"},
+  {__LINE__, "   ", 0, TEST_ALL, "Just whitespace"},
+  {__LINE__, ".", 0, TEST_ALL, "Just decimal point"},
+  {__LINE__, "+", 0, TEST_ALL, "Just plus"},
+  {__LINE__, "-", 0, TEST_ALL, "Just minus"},
+  {__LINE__, "abc", 0, TEST_ALL, "No digits"},
+  {__LINE__, "0x123", 1, TEST_ALL, "Hex prefix not supported (stops at x)"},
+  {__LINE__, "0X123", 1, TEST_ALL, "Hex prefix uppercase not supported"},
+
+  /* Complete exponents are fully consumed. */
+  {__LINE__, "1E+2", 4, TEST_ALL, "Signed positive exponent consumed"},
+  {__LINE__, "1e2junk", 3, TEST_ALL, "Exponent value then letters"},
+  {__LINE__, "1e00000000000000000010", 22, TEST_ALL, "Exponent with many leading zeros consumed"},
+
+  /* Overflow/underflow still consume the whole numeric token. */
+  {__LINE__, "1E999999999", 11, TEST_ALL, "Overflowing exponent still fully consumed"},
+  {__LINE__, "0.0e-100000", 11, TEST_ALL, "Huge-exponent zero fully consumed"},
+
+  /* Fraction and integer forms without the optional other part. */
+  {__LINE__, "+.5", 3, TEST_ALL, "Signed fraction with no integer part"},
+  {__LINE__, "1.", 2, TEST_ALL, "Trailing decimal point is consumed"},
+  {__LINE__, "5.e3", 4, TEST_ALL, "Integer, point, then exponent"},
+
+  /* Long fully-valid tokens are consumed in their entirety. */
+  {__LINE__, "9999999999999999999999999999999999999999", 40, TEST_ALL, "Long integer fully consumed"},
+
+  /* Leading whitespace is skipped; all five characters are consumed. */
+  {__LINE__, "\f\v123", 5, TEST_ALL, "Form-feed and vertical-tab whitespace skipped"},
+
+  /* "INF" is a valid prefix; longer partial matches of "INFINITY" only
+     consume "inf" and leave the rest.  C23 accepts either INF or INFINITY. */
+  {__LINE__, "infin", 3, TEST_ALL, "Partial INFINITY consumes only inf"},
+  {__LINE__, "infinit", 3, TEST_ALL, "INFINITY missing final y consumes only inf"},
+  {__LINE__, "INFINITYYY", 8, TEST_ALL, "Full INFINITY then extra letters"},
+
+  /* A NaN with no closing parenthesis is not a valid n-char-sequence, so only
+     the bare "nan" is consumed and "(..." is left unparsed. */
+  {__LINE__, "nan(123", 3, TEST_ALL, "NaN payload without closing paren consumes only nan"},
+
+  /* NaN payload may contain letters and underscores (C23 n-char-sequence).
+     KNOWN BUG: endptr stops on the ')' rather than after it (off by one). */
+  {__LINE__, "nan(a_9)", 8, TEST_ALL, "NaN payload with letters and underscore"},
+
+  /* C23 does not permit white space between the sign and the subject. */
+  {__LINE__, "+ 1", 0, TEST_ALL, "Space between plus sign and digits"},
+  {__LINE__, "- inf", 0, TEST_ALL, "Space between minus sign and inf"},
+
+  /* Decimal point with no fractional digits, followed by an empty exponent:
+     the "1." is a valid number and the stray 'e' is left unparsed. */
+  {__LINE__, "1.e", 2, TEST_ALL, "Trailing point then empty exponent"},
+  {0, NULL, 0, 0, NULL}
 };
 
 // Validate the pointer returned in endptr is as expected.
@@ -156,8 +493,8 @@ static void check_endptr(const char *input, const char *endptr, size_t n, int li
     const char *input_end = input + l;
     if (endptr < input || endptr > input_end)
       {
-	fprintf (stderr, "%-3d Error: *endptr is not within input string\n", testnum);
-	fprintf (stderr, "    in: %s:%d.\n\n",__FILE__,line);
+	fprintf (stdout, "%-3d Error: *endptr is not within input string\n", testnum);
+	fprintf (stdout, "    in: %s:%d.\n\n",__FILE__,line);
 	++fail;
       }
     else
@@ -165,8 +502,8 @@ static void check_endptr(const char *input, const char *endptr, size_t n, int li
 	size_t rem = input_end - endptr;
 	if (rem != n)
 	  {
-	    fprintf (stderr, "%-3d Error: *endptr leaves %d characters. Expected %d.\n", testnum, (int) rem, (int) n);
-	    fprintf (stderr, "in: %s:%d.\n\n",__FILE__,line);
+	    fprintf (stdout, "%-3d Error: *endptr leaves %d characters. Expected %d.\n", testnum, (int) rem, (int) n);
+	    fprintf (stdout, "in: %s:%d.\n\n",__FILE__,line);
 	    ++fail;
 	  }
       }
@@ -177,8 +514,8 @@ static void check_wendptr(const wchar_t *input, const wchar_t *endptr, size_t n,
     const wchar_t *input_end = input + l;
     if (endptr < input || endptr > input_end)
       {
-	fprintf (stderr, "%-3d Error: *wendptr is not within input string\n", testnum);
-	fprintf (stderr, "    in: %s:%d.\n\n",__FILE__,line);
+	fprintf (stdout, "%-3d Error: *wendptr is not within input string\n", testnum);
+	fprintf (stdout, "    in: %s:%d.\n\n",__FILE__,line);
 	++fail;
       }
     else
@@ -186,8 +523,8 @@ static void check_wendptr(const wchar_t *input, const wchar_t *endptr, size_t n,
 	size_t rem = input_end - endptr;
 	if (rem != n)
 	  {
-	    fprintf (stderr, "%-3d Error: *wendptr leaves %d characters. Expected %d.\n", testnum, (int) rem, (int) n);
-	    fprintf (stderr, "in: %s:%d.\n\n",__FILE__,line);
+	    fprintf (stdout, "%-3d Error: *wendptr leaves %d characters. Expected %d.\n", testnum, (int) rem, (int) n);
+	    fprintf (stdout, "in: %s:%d.\n\n",__FILE__,line);
 	    ++fail;
 	  }
       }
@@ -196,8 +533,8 @@ static void check_wendptr(const wchar_t *input, const wchar_t *endptr, size_t n,
 static void check_qexp(int line, int expected_qexp, int qexp, int type) {
   if (qexp != expected_qexp)
     {
-      fprintf (stderr, "%-3d Error: expected quantum exponent %d, got %d for _Decimal%d\n", testnum, expected_qexp, qexp, type);
-      fprintf (stderr, "in: %s:%d.\n\n",__FILE__,line);
+      fprintf (stdout, "%-3d Error: expected quantum exponent %d, got %d for _Decimal%d\n", testnum, expected_qexp, qexp, type);
+      fprintf (stdout, "in: %s:%d.\n\n",__FILE__,line);
       ++fail;
     }
 }
@@ -205,8 +542,8 @@ static void check_qexp(int line, int expected_qexp, int qexp, int type) {
 static void check_zero_sign(int line, int type, bool same_sign, bool is_zero) {
   if (is_zero && !same_sign)
     {
-      fprintf (stderr, "%-3d Error: incorrect zero sign returned for _Decimal%d\n", testnum, type);
-      fprintf (stderr, "in: %s:%d.\n\n",__FILE__,line);
+      fprintf (stdout, "%-3d Error: incorrect zero sign returned for _Decimal%d\n", testnum, type);
+      fprintf (stdout, "in: %s:%d.\n\n",__FILE__,line);
       ++fail;
     }
 }
@@ -215,7 +552,7 @@ static void copy_to_wstr(wchar_t *dest, const char *src, size_t dest_len) {
   size_t cvt_status = mbstowcs(dest, src, dest_len);
   if (((size_t)-1 == cvt_status) || (dest_len == cvt_status))
     {
-      fprintf (stderr, "failed to convert %s to wchar (%zu)\n", src, cvt_status);
+      fprintf (stdout, "failed to convert %s to wchar (%zu)\n", src, cvt_status);
       exit (1);
     }
 }
@@ -234,14 +571,82 @@ static void copy_to_wstr(wchar_t *dest, const char *src, size_t dest_len) {
 #define RUN_ONE_TEST(pfx,wid,inptr,eptr,checker, pf_mod) \
       endptr = NULL; \
       _Decimal ## wid result ## wid ## pfx = pfx ## tod ## wid (inptr, NULL); \
-      fprintf (stdout, #pfx "tod" #wid "(\"%s\",NULL) == " pf_mod  "\n  ", dptr->input, result ## wid ## pfx); \
+      if (verbose) fprintf (stdout, #pfx "tod" #wid "(\"%s\",NULL) == " pf_mod  "\n  ", dptr->input, result ## wid ## pfx); \
       _VC_P (__FILE__, dptr->line, dptr->d ## wid, result ## wid ## pfx, pf_mod); \
       _VC_P (__FILE__, dptr->line, dptr->d ## wid, pfx ## tod ## wid (inptr, &eptr), pf_mod); \
       checker (inptr, eptr, dptr->rem, dptr->line); \
       CHECK_ZERO_SIGN (dptr, result ## wid ## pfx, wid); \
       CHECK_QEXP (dptr, result ## wid ## pfx, wid);
 
-int main(void) {
+static void run_errno_tests(void) {
+  errno_test *test;
+  test_type_flags types[] = {TEST_D32, TEST_D64, TEST_D128};
+
+  for (test = overflow_errno_tests; test->input != NULL; test++) {
+    for (int t = 0; t < _TEST_TYPE_CNT; t++) {
+      if (!(test->types & types[t]))
+        continue;
+
+      testnum++;
+      errno = 0;
+      switch (types[t]) {
+        case TEST_D32: strtod32(test->input, NULL); break;
+        case TEST_D64: strtod64(test->input, NULL); break;
+        case TEST_D128: strtod128(test->input, NULL); break;
+      }
+      /* Check errno */
+      if (test->expected_errno != errno) {
+        fprintf(stdout, "%-3d Error: %s (D%d) - unexpected errno result\n", testnum, test->description, types[t]*32);
+        fprintf(stdout, "    Input: \"%s\"\n", test->input);
+        fprintf(stdout, "    Expected errno %d, got %d\n", test->expected_errno, errno);
+        fprintf(stdout, "    in: %s:%d\n\n", __FILE__, test->line);
+        ++fail;
+      }
+    }
+  }
+}
+
+static void run_endptr_tests(void) {
+  endptr_test *test;
+  test_type_flags types[] = {TEST_D32, TEST_D64, TEST_D128};
+
+  for (test = endptr_tests; test->input != NULL; test++) {
+    for (int t = 0; t < _TEST_TYPE_CNT; t++) {
+      if (!(test->types & types[t]))
+        continue;
+
+      ++testnum;
+      char *endptr = NULL;
+        switch (types[t]) {
+          case TEST_D32: strtod32(test->input, &endptr); break;
+          case TEST_D64: strtod64(test->input, &endptr); break;
+          case TEST_D128: strtod128(test->input, &endptr); break;
+        }
+
+        if (endptr == NULL) {
+          fprintf(stdout, "%-3d Error: %s (D%d)\n", testnum, test->description, types[t]*32);
+          fprintf(stdout, "    Input: \"%s\"\n", test->input);
+          fprintf(stdout, "    endptr is NULL\n");
+          fprintf(stdout, "    in: %s:%d\n\n", __FILE__, test->line);
+          ++fail;
+          continue;
+        }
+
+        size_t chars_parsed = endptr - test->input;
+        if (chars_parsed != test->expected_chars_parsed) {
+          fprintf(stdout, "%-3d Error: %s (D%d)\n", testnum, test->description, types[t]*32);
+          fprintf(stdout, "    Input: \"%s\"\n", test->input);
+          fprintf(stdout, "    Expected %zu chars parsed, got %zu\n",
+                  test->expected_chars_parsed, chars_parsed);
+          fprintf(stdout, "    endptr points to: \"%s\"\n", endptr);
+          fprintf(stdout, "    in: %s:%d\n\n", __FILE__, test->line);
+          ++fail;
+        }
+    }
+  }
+}
+
+int main(int argc, char *argv[]) {
 
   d_type *dptr;
   char *endptr = NULL;
@@ -249,16 +654,25 @@ int main(void) {
 
   wchar_t winput[WCHAR_BUF_LEN];
 
+  verbose = 0; // Make passing results quiet by default.
+
+  /* Parse command-line arguments */
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
+      verbose = 1;
+    }
+  }
+
   for (dptr = strtods; dptr->line; dptr++)
     {
       copy_to_wstr (winput, dptr->input, WCHAR_BUF_LEN);
 
-      RUN_ONE_TEST (str, 32, dptr->input, endptr, check_endptr, "%Hf")
-      RUN_ONE_TEST (wcs, 32, winput, wendptr, check_wendptr, "%Hf")
-      RUN_ONE_TEST (str, 64, dptr->input, endptr, check_endptr, "%Df")
-      RUN_ONE_TEST (wcs, 64, winput, wendptr, check_wendptr, "%Df")
-      RUN_ONE_TEST (str, 128, dptr->input, endptr, check_endptr, "%DDf")
-      RUN_ONE_TEST (wcs, 128, winput, wendptr, check_wendptr, "%DDf")
+      RUN_ONE_TEST (str, 32, dptr->input, endptr, check_endptr, "%.6He")
+      RUN_ONE_TEST (wcs, 32, winput, wendptr, check_wendptr, "%.6He")
+      RUN_ONE_TEST (str, 64, dptr->input, endptr, check_endptr, "%.15De")
+      RUN_ONE_TEST (wcs, 64, winput, wendptr, check_wendptr, "%.15De")
+      RUN_ONE_TEST (str, 128, dptr->input, endptr, check_endptr, "%.33DDe")
+      RUN_ONE_TEST (wcs, 128, winput, wendptr, check_wendptr, "%.33DDe")
     }
 
   d_nan_type *dnanptr;
@@ -270,6 +684,9 @@ int main(void) {
       _DC_P(__FILE__, dnanptr->line,dnanptr->d64, strtod64(dnanptr->input, NULL));
       _DC_P(__FILE__, dnanptr->line,dnanptr->d128, strtod128(dnanptr->input, NULL));
     }
+
+  run_errno_tests();
+  run_endptr_tests();
 
   _REPORT();
 

--- a/tests/test-strtod.c
+++ b/tests/test-strtod.c
@@ -709,6 +709,56 @@ endptr_test endptr_tests[] = {
   {0, NULL, 0, 0, NULL}
 };
 
+/* Sign of a parsed NaN.  A NaN carries a sign bit like any other value, and
+   strtodN()/wcstodN() have to honour the optional sign character in front of
+   the subject sequence, so "-nan" must come back negative just as "-inf" comes
+   back as -infinity.  Nothing else in this file can see that: _VC_P() treats
+   any two NaNs as equal whatever their signs, and the declet comparisons in
+   strtods_nan[] go through decoded32/64/128(), which bail out on every special
+   encoding (see the DECLET_HUGE_VAL_* note above).  These entries therefore
+   look at isnan() and signbit() directly.  */
+typedef struct {
+  int line;
+  const char *input;
+  int negative;			/* Expected signbit of the result.  */
+  size_t rem;			/* Characters left unparsed.  */
+  const char *description;
+} nan_sign_test;
+
+nan_sign_test nan_sign_tests[] = {
+  /* Unsigned and explicitly positive NaNs, in a few case spellings. */
+  {__LINE__, "nan", 0, 0, "Bare NaN is positive"},
+  {__LINE__, "NAN", 0, 0, "Upper case NaN is positive"},
+  {__LINE__, "NaN", 0, 0, "Mixed case NaN is positive"},
+  {__LINE__, "nAn", 0, 0, "Alternate mixed case NaN is positive"},
+  {__LINE__, "+nan", 0, 0, "Explicitly positive NaN"},
+  {__LINE__, "+NAN", 0, 0, "Explicitly positive upper case NaN"},
+
+  /* Negative NaNs. */
+  {__LINE__, "-nan", 1, 0, "Negative NaN"},
+  {__LINE__, "-NAN", 1, 0, "Negative upper case NaN"},
+  {__LINE__, "-NaN", 1, 0, "Negative mixed case NaN"},
+
+  /* The sign applies to a NaN carrying an n-char-sequence just the same. */
+  {__LINE__, "nan()", 0, 0, "Positive NaN with empty payload"},
+  {__LINE__, "-nan()", 1, 0, "Negative NaN with empty payload"},
+  {__LINE__, "nan(123)", 0, 0, "Positive NaN with digit payload"},
+  {__LINE__, "-nan(123)", 1, 0, "Negative NaN with digit payload"},
+  {__LINE__, "-nan(a_9)", 1, 0, "Negative NaN with alphanumeric payload"},
+
+  /* An unterminated payload is not part of the subject sequence, so only the
+     bare "-nan" is consumed -- but its sign still has to be right. */
+  {__LINE__, "-nan(123", 1, 4, "Negative NaN with unterminated payload"},
+
+  /* Leading whitespace before the sign, and trailing text after the subject
+     sequence, must not disturb the sign either. */
+  {__LINE__, "  -nan", 1, 0, "Negative NaN after whitespace"},
+  {__LINE__, "\t\n-nan", 1, 0, "Negative NaN after tab and newline"},
+  {__LINE__, "-nanxyz", 1, 3, "Negative NaN then text"},
+  {__LINE__, "-nan(123)xyz", 1, 3, "Negative NaN with payload then text"},
+  {0, NULL, 0, 0, NULL}
+};
+
 // Validate the pointer returned in endptr is as expected.
 static void check_endptr(const char *input, const char *endptr, size_t n, int line) {
     size_t l = strlen(input);
@@ -882,6 +932,53 @@ static void run_endptr_tests(void) {
   }
 }
 
+static void check_nan_sign(int line, const char *input, int width,
+			   const char *fn, int is_nan, int negative,
+			   int expected_negative, const char *description) {
+  ++testnum;
+  if (!is_nan || negative != expected_negative)
+    {
+      fprintf (stdout, "%-3d Error: %s (%stod%d) - expected %sNaN, got %s%s\n",
+	       testnum, description, fn, width,
+	       expected_negative ? "-" : "+", negative ? "-" : "+",
+	       is_nan ? "NaN" : "a non-NaN value");
+      fprintf (stdout, "    Input: \"%s\"\n", input);
+      fprintf (stdout, "    in: %s:%d\n\n", __FILE__, line);
+      ++fail;
+    }
+  else if (verbose)
+    fprintf (stdout, "%-3d Success: %s (%stod%d) == %sNaN\n\n",
+	     testnum, description, fn, width, expected_negative ? "-" : "+");
+}
+
+#define RUN_ONE_NAN_TEST(pfx,wid,inptr,eptr,checker) \
+      do { \
+	eptr = NULL; \
+	_Decimal ## wid result = pfx ## tod ## wid (inptr, &eptr); \
+	check_nan_sign (test->line, test->input, wid, #pfx, isnan (result), \
+			!!signbit (result), test->negative, \
+			test->description); \
+	checker (inptr, eptr, test->rem, test->line); \
+      } while (0)
+
+static void run_nan_sign_tests(void) {
+  nan_sign_test *test;
+  wchar_t winput[WCHAR_BUF_LEN];
+  char *endptr;
+  wchar_t *wendptr;
+
+  for (test = nan_sign_tests; test->input != NULL; test++) {
+    copy_to_wstr (winput, test->input, WCHAR_BUF_LEN);
+
+    RUN_ONE_NAN_TEST (str, 32, test->input, endptr, check_endptr);
+    RUN_ONE_NAN_TEST (wcs, 32, winput, wendptr, check_wendptr);
+    RUN_ONE_NAN_TEST (str, 64, test->input, endptr, check_endptr);
+    RUN_ONE_NAN_TEST (wcs, 64, winput, wendptr, check_wendptr);
+    RUN_ONE_NAN_TEST (str, 128, test->input, endptr, check_endptr);
+    RUN_ONE_NAN_TEST (wcs, 128, winput, wendptr, check_wendptr);
+  }
+}
+
 int main(int argc, char *argv[]) {
 
   d_type *dptr;
@@ -923,6 +1020,7 @@ int main(int argc, char *argv[]) {
 
   run_errno_tests();
   run_endptr_tests();
+  run_nan_sign_tests();
 
   _REPORT();
 

--- a/tests/test-strtod.c
+++ b/tests/test-strtod.c
@@ -788,7 +788,7 @@ static void copy_to_wstr(wchar_t *dest, const char *src, size_t dest_len) {
 			signbit(result) == signbit(dptr->d ## type), \
 			result == 0.DL)
 
-#define WCHAR_BUF_LEN (256)
+#define WCHAR_BUF_LEN (7000)
 
 #define RUN_ONE_TEST(pfx,wid,inptr,eptr,checker, pf_mod) \
       endptr = NULL; \
@@ -803,24 +803,43 @@ static void copy_to_wstr(wchar_t *dest, const char *src, size_t dest_len) {
 static void run_errno_tests(void) {
   errno_test *test;
   test_type_flags types[] = {TEST_D32, TEST_D64, TEST_D128};
+  wchar_t winput[WCHAR_BUF_LEN];
 
   for (test = overflow_errno_tests; test->input != NULL; test++) {
+    copy_to_wstr (winput, test->input, WCHAR_BUF_LEN);
     for (int t = 0; t < _TEST_TYPE_CNT; t++) {
       if (!(test->types & types[t]))
         continue;
 
       testnum++;
       errno = 0;
+      int werrno = 0;
       switch (types[t]) {
-        case TEST_D32: strtod32(test->input, NULL); break;
-        case TEST_D64: strtod64(test->input, NULL); break;
-        case TEST_D128: strtod128(test->input, NULL); break;
+        case TEST_D32:
+          wcstod32(winput, NULL);
+	  werrno = errno;
+	  errno = 0;
+          strtod32(test->input, NULL);
+          break;
+        case TEST_D64:
+          strtod64(test->input, NULL);
+	  werrno = errno;
+	  errno = 0;
+          wcstod64(winput, NULL);
+          break;
+        case TEST_D128:
+          strtod128(test->input, NULL);
+	  werrno = errno;
+	  errno = 0;
+          wcstod128(winput, NULL);
+          break;
       }
       /* Check errno */
-      if (test->expected_errno != errno) {
+      if (test->expected_errno != errno || werrno != errno) {
         fprintf(stdout, "%-3d Error: %s (D%d) - unexpected errno result\n", testnum, test->description, types[t]*32);
         fprintf(stdout, "    Input: \"%s\"\n", test->input);
         fprintf(stdout, "    Expected errno %d, got %d\n", test->expected_errno, errno);
+        fprintf(stdout, "    wcs got %d\n", werrno);
         fprintf(stdout, "    in: %s:%d\n\n", __FILE__, test->line);
         ++fail;
       }
@@ -831,39 +850,34 @@ static void run_errno_tests(void) {
 static void run_endptr_tests(void) {
   endptr_test *test;
   test_type_flags types[] = {TEST_D32, TEST_D64, TEST_D128};
+  wchar_t winput[WCHAR_BUF_LEN];
 
   for (test = endptr_tests; test->input != NULL; test++) {
+    copy_to_wstr (winput, test->input, WCHAR_BUF_LEN);
+
     for (int t = 0; t < _TEST_TYPE_CNT; t++) {
       if (!(test->types & types[t]))
         continue;
 
       ++testnum;
       char *endptr = NULL;
-        switch (types[t]) {
-          case TEST_D32: strtod32(test->input, &endptr); break;
-          case TEST_D64: strtod64(test->input, &endptr); break;
-          case TEST_D128: strtod128(test->input, &endptr); break;
-        }
-
-        if (endptr == NULL) {
-          fprintf(stdout, "%-3d Error: %s (D%d)\n", testnum, test->description, types[t]*32);
-          fprintf(stdout, "    Input: \"%s\"\n", test->input);
-          fprintf(stdout, "    endptr is NULL\n");
-          fprintf(stdout, "    in: %s:%d\n\n", __FILE__, test->line);
-          ++fail;
-          continue;
-        }
-
-        size_t chars_parsed = endptr - test->input;
-        if (chars_parsed != test->expected_chars_parsed) {
-          fprintf(stdout, "%-3d Error: %s (D%d)\n", testnum, test->description, types[t]*32);
-          fprintf(stdout, "    Input: \"%s\"\n", test->input);
-          fprintf(stdout, "    Expected %zu chars parsed, got %zu\n",
-                  test->expected_chars_parsed, chars_parsed);
-          fprintf(stdout, "    endptr points to: \"%s\"\n", endptr);
-          fprintf(stdout, "    in: %s:%d\n\n", __FILE__, test->line);
-          ++fail;
-        }
+      wchar_t *wendptr = NULL;
+      switch (types[t]) {
+        case TEST_D32:
+          strtod32(test->input, &endptr);
+          wcstod32(winput, &wendptr);
+          break;
+        case TEST_D64:
+          strtod64(test->input, &endptr);
+          wcstod64(winput, &wendptr);
+          break;
+        case TEST_D128:
+          strtod128(test->input, &endptr);
+          wcstod128(winput, &wendptr);
+          break;
+      }
+      check_endptr(test->input, endptr, strlen(test->input) - test->expected_chars_parsed, test->line);
+      check_wendptr(winput, wendptr, wcslen(winput) - test->expected_chars_parsed, test->line);
     }
   }
 }

--- a/tests/test-strtod.c
+++ b/tests/test-strtod.c
@@ -231,8 +231,113 @@ d_type strtods[] =
      bit, so _Decimal32 rounds 1.2345665|0001 to 1.234566 instead of 1.234567. */
   {__LINE__, "1.23456650001", 1.234567DF, -6, 1.23456650001DD, -11, 1.23456650001DL, -11, 0},
 
+  /* --- Long integer components ---
+     Numbers whose *integer* part has more digits than the destination format
+     can hold.  strtodN() accumulates the integer digits one at a time, so
+     every digit past the format's precision is a rounding opportunity; only
+     the very first one is allowed to change the result.  The correctly
+     rounded answer always depends on all of the remaining digits (the sticky
+     bit), never on the intermediate roundings.  */
+
+  /* Integer parts that simply exceed the precision of one or more formats. */
+  {__LINE__, "1234567890", 1.234568E9DF, 3, 1.234567890E9DD, 0, 1.234567890E9DL, 0, 0},
+  {__LINE__, "123456789012345678", 1.234568E17DF, 11, 1.234567890123457E17DD, 2,
+   1.23456789012345678E17DL, 0, 0},
+  {__LINE__, "12345678901234567890123456789012345", 1.234568E34DF, 28,
+   1.234567890123457E34DD, 19, 1.234567890123456789012345678901234E34DL, 1, 0},
+
+  /* 37 nines: the rounding carry ripples the whole way out of the coefficient
+     and bumps the exponent for every format. */
+  {__LINE__, "9999999999999999999999999999999999999", 1.000000E37DF, 31,
+   1.000000000000000E37DD, 22, 1.000000000000000000000000000000000E37DL, 4, 0},
+
+  /* Exact ties in the integer part: one guard digit of 5 and nothing after
+     it, so the tie breaks toward the even coefficient digit. */
+  {__LINE__, "12345645", 1.234564E7DF, 1, 1.2345645E7DD, 0, 1.2345645E7DL, 0, 0},
+  {__LINE__, "1234567890123456500", 1.234568E18DF, 12, 1.234567890123456E18DD, 3,
+   1.234567890123456500E18DL, 0, 0},
+
+  /* Guard digit 5 in the integer part *followed* by more nonzero digits: the
+     value is strictly above the halfway point and must round up.  Rounding
+     digit-by-digit turns the 5 into a tie, rounds it to even, and then loses
+     the trailing digits, giving a result one ULP too small. */
+  {__LINE__, "123456455", 1.234565E8DF, 2, 1.23456455E8DD, 0, 1.23456455E8DL, 0, 0},
+  {__LINE__, "1234564550", 1.234565E9DF, 3, 1.234564550E9DD, 0, 1.234564550E9DL, 0, 0},
+  {__LINE__, "12345645000001", 1.234565E13DF, 7, 1.2345645000001E13DD, 0,
+   1.2345645000001E13DL, 0, 0},
+  {__LINE__, "123456789012345655", 1.234568E17DF, 11, 1.234567890123457E17DD, 2,
+   1.23456789012345655E17DL, 0, 0},
+  {__LINE__, "1234567890123456789012345678901234550", 1.234568E36DF, 30,
+   1.234567890123457E36DD, 21, 1.234567890123456789012345678901235E36DL, 3, 0},
+
+  /* A long integer part with a fraction after it.  The fractional digits are
+     past the precision of the smaller formats but still contribute the sticky
+     bit that decides the rounding of the integer part. */
+  {__LINE__, "12345665.9", 1.234567E7DF, 1, 1.23456659E7DD, -1, 1.23456659E7DL, -1, 0},
+  {__LINE__, "12345675.9", 1.234568E7DF, 1, 1.23456759E7DD, -1, 1.23456759E7DL, -1, 0},
+  {__LINE__, "12345678901234565.5", 1.234568E16DF, 10, 1.234567890123457E16DD, 1,
+   1.23456789012345655E16DL, -1, 0},
+  {__LINE__, "99999999999999999999.99999999999999999999", 1.000000E20DF, 14,
+   1.000000000000000E20DD, 5, 1.000000000000000000000000000000000E20DL, -13, 0},
+
+  /* Long integer part combined with an exponent, in both directions. */
+  {__LINE__, "12345678901234567890e10", 1.234568E29DF, 23, 1.234567890123457E29DD, 14,
+   1.2345678901234567890E29DL, 10, 0},
+  {__LINE__, "12345678901234567890e-10", 1.234568E9DF, 3, 1.234567890123457E9DD, -6,
+   1.2345678901234567890E9DL, -10, 0},
+  {__LINE__, "1234567890123456789012345678901234e-100", 1.234568E-67DF, -73,
+   1.234567890123457E-67DD, -82, 1.234567890123456789012345678901234E-67DL, -100, 0},
+
+  /* Leading zeroes must not count toward the integer digit count. */
+  {__LINE__, "00000000000012345678901234567890", 1.234568E19DF, 13,
+   1.234567890123457E19DD, 4, 1.2345678901234567890E19DL, 0, 0},
+
+  /* Negative sign in front of a long integer. */
+  {__LINE__, "-1234567890123456789012345678901234567890", -1.234568E39DF, 33,
+   -1.234567890123457E39DD, 24, -1.234567890123456789012345678901235E39DL, 6, 0},
+
+  /* A long integer that is exactly representable: only the leading digit is
+     significant, so no rounding happens and the quantum is the written one
+     (clamped down for _Decimal32, whose largest quantum exponent is 90). */
+  {__LINE__, "100000000000000000000", 1.000000E20DF, 14, 1.000000000000000E20DD, 5,
+   1.00000000000000000000E20DL, 0, 0},
+
+  /* 121 and 120 integer digits pulled back into range by a negative exponent.
+     The digit count alone exceeds every format's exponent range, so the
+     normalisation of int_no against the exponent has to happen before the
+     range check. */
+  {__LINE__, "1"  "0000000000" "0000000000" "0000000000" "0000000000"
+	     "0000000000" "0000000000" "0000000000" "0000000000"
+	     "0000000000" "0000000000" "0000000000" "0000000000" "e-40",
+   1.000000E80DF, 74, 1.000000000000000E80DD, 65,
+   1.000000000000000000000000000000000E80DL, 47, 0},
+  {__LINE__, "9999999999" "9999999999" "9999999999" "9999999999"
+	     "9999999999" "9999999999" "9999999999" "9999999999"
+	     "9999999999" "9999999999" "9999999999" "9999999999" "e-40",
+   1.000000E80DF, 74, 1.000000000000000E80DD, 65,
+   1.000000000000000000000000000000000E80DL, 47, 0},
+
   {0,0,0,0,0,0,0,0,0 }
 };
+
+/* Runs of nines used to build integer parts long enough to reach each
+   format's maximum exponent.  */
+#define N10	"9999999999"
+#define N100	N10 N10 N10 N10 N10 N10 N10 N10 N10 N10
+#define N1000	N100 N100 N100 N100 N100 N100 N100 N100 N100 N100
+#define Z10	"0000000000"
+
+/* Exactly __DEC32_MAX_EXP__ (97) nines, and one digit fewer.  */
+#define NINES_D32_OVER	N10 N10 N10 N10 N10 N10 N10 N10 N10 "9999999"
+#define NINES_D32_FIT	N10 N10 N10 N10 N10 N10 N10 N10 N10 "999999"
+/* Exactly __DEC64_MAX_EXP__ (385) nines, and one digit fewer.  */
+#define NINES_D64_OVER	N100 N100 N100 N10 N10 N10 N10 N10 N10 N10 N10 "99999"
+#define NINES_D64_FIT	N100 N100 N100 N10 N10 N10 N10 N10 N10 N10 N10 "9999"
+/* Exactly __DEC128_MAX_EXP__ (6145) nines, and one digit fewer.  */
+#define NINES_D128_OVER	N1000 N1000 N1000 N1000 N1000 N1000 N100 \
+			N10 N10 N10 N10 "99999"
+#define NINES_D128_FIT	N1000 N1000 N1000 N1000 N1000 N1000 N100 \
+			N10 N10 N10 N10 "9999"
 
 const char DECLET32_NAN[] = "+0,000,000E-101";
 const char DECLET64_NAN[] = "+0,000,000,000,000,000E-398";
@@ -332,6 +437,83 @@ d_nan_type strtods_nan[] =
   /* Same flaw at the _Decimal128 subnormal boundary.  The D128 field is buggy. */
   {__LINE__, "6E-6177", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,001E-6176" }, /* D128 -> 1E-6176 */
   {__LINE__, "1.5E-6176", DECLET_ZERO_D32, DECLET_ZERO_D64, "+0,000,000,000,000,000,000,000,000,000,000,002E-6176" }, /* D128 -> 2E-6176 */
+
+  /* --- Long integer components, exact coefficient and quantum ---
+     The same inputs as the "Long integer components" block in strtods[],
+     checked here for the exact coefficient/exponent pair rather than just
+     numeric equality. */
+
+  /* Truncating a long integer must keep the coefficient full width and move
+     the quantum exponent up, not renormalise the coefficient. */
+  {__LINE__, "1234567890", "+1,234,568E+3", "+0,000,001,234,567,890E+0",
+   "+0,000,000,000,000,000,000,000,001,234,567,890E+0" },
+  {__LINE__, "123456789012345678", "+1,234,568E+11", "+1,234,567,890,123,457E+2",
+   "+0,000,000,000,000,000,123,456,789,012,345,678E+0" },
+  {__LINE__, "12345678901234567890123456789012345", "+1,234,568E+28",
+   "+1,234,567,890,123,457E+19", "+1,234,567,890,123,456,789,012,345,678,901,234E+1" },
+
+  /* Carry out of the top digit leaves a 1 followed by zeroes. */
+  {__LINE__, "9999999999999999999999999999999999999", "+1,000,000E+31",
+   "+1,000,000,000,000,000E+22", "+1,000,000,000,000,000,000,000,000,000,000,000E+4" },
+
+  /* Exact ties in the integer part round to even. */
+  {__LINE__, "12345645", "+1,234,564E+1", "+0,000,000,012,345,645E+0",
+   "+0,000,000,000,000,000,000,000,000,012,345,645E+0" },
+  {__LINE__, "1234567890123456500", "+1,234,568E+12", "+1,234,567,890,123,456E+3",
+   "+0,000,000,000,000,001,234,567,890,123,456,500E+0" },
+
+  /* Guard digit 5 followed by nonzero digits rounds up. */
+  {__LINE__, "123456455", "+1,234,565E+2", "+0,000,000,123,456,455E+0",
+   "+0,000,000,000,000,000,000,000,000,123,456,455E+0" },
+  {__LINE__, "1234564550", "+1,234,565E+3", "+0,000,001,234,564,550E+0",
+   "+0,000,000,000,000,000,000,000,001,234,564,550E+0" },
+  {__LINE__, "12345645000001", "+1,234,565E+7", "+0,012,345,645,000,001E+0",
+   "+0,000,000,000,000,000,000,012,345,645,000,001E+0" },
+  {__LINE__, "123456789012345655", "+1,234,568E+11", "+1,234,567,890,123,457E+2",
+   "+0,000,000,000,000,000,123,456,789,012,345,655E+0" },
+  {__LINE__, "1234567890123456789012345678901234550", "+1,234,568E+30",
+   "+1,234,567,890,123,457E+21", "+1,234,567,890,123,456,789,012,345,678,901,235E+3" },
+
+  /* Fractional digits supply the sticky bit for a long integer part. */
+  {__LINE__, "12345665.9", "+1,234,567E+1", "+0,000,000,123,456,659E-1",
+   "+0,000,000,000,000,000,000,000,000,123,456,659E-1" },
+  {__LINE__, "12345675.9", "+1,234,568E+1", "+0,000,000,123,456,759E-1",
+   "+0,000,000,000,000,000,000,000,000,123,456,759E-1" },
+  {__LINE__, "12345678901234565.5", "+1,234,568E+10", "+1,234,567,890,123,457E+1",
+   "+0,000,000,000,000,000,123,456,789,012,345,655E-1" },
+  {__LINE__, "99999999999999999999.99999999999999999999", "+1,000,000E+14",
+   "+1,000,000,000,000,000E+5", "+1,000,000,000,000,000,000,000,000,000,000,000E-13" },
+
+  /* Long integer part with an exponent. */
+  {__LINE__, "12345678901234567890e10", "+1,234,568E+23", "+1,234,567,890,123,457E+14",
+   "+0,000,000,000,000,012,345,678,901,234,567,890E+10" },
+  {__LINE__, "12345678901234567890e-10", "+1,234,568E+3", "+1,234,567,890,123,457E-6",
+   "+0,000,000,000,000,012,345,678,901,234,567,890E-10" },
+  {__LINE__, "1234567890123456789012345678901234e-100", "+1,234,568E-73",
+   "+1,234,567,890,123,457E-82", "+1,234,567,890,123,456,789,012,345,678,901,234E-100" },
+
+  /* Leading zeroes do not count as integer digits. */
+  {__LINE__, "00000000000012345678901234567890", "+1,234,568E+13",
+   "+1,234,567,890,123,457E+4", "+0,000,000,000,000,012,345,678,901,234,567,890E+0" },
+  {__LINE__, "-1234567890123456789012345678901234567890", "-1,234,568E+33",
+   "-1,234,567,890,123,457E+24", "-1,234,567,890,123,456,789,012,345,678,901,235E+6" },
+
+  /* Exactly representable long integer: _Decimal32 has to clamp the quantum
+     exponent to 90 and pad the coefficient, the wider formats do not. */
+  {__LINE__, "100000000000000000000", "+1,000,000E+14", "+1,000,000,000,000,000E+5",
+   "+0,000,000,000,000,100,000,000,000,000,000,000E+0" },
+
+  /* 121/120 integer digits brought back into range by "e-40". */
+  {__LINE__, "1"  "0000000000" "0000000000" "0000000000" "0000000000"
+	     "0000000000" "0000000000" "0000000000" "0000000000"
+	     "0000000000" "0000000000" "0000000000" "0000000000" "e-40",
+   "+1,000,000E+74", "+1,000,000,000,000,000E+65",
+   "+1,000,000,000,000,000,000,000,000,000,000,000E+47" },
+  {__LINE__, "9999999999" "9999999999" "9999999999" "9999999999"
+	     "9999999999" "9999999999" "9999999999" "9999999999"
+	     "9999999999" "9999999999" "9999999999" "9999999999" "e-40",
+   "+1,000,000E+74", "+1,000,000,000,000,000E+65",
+   "+1,000,000,000,000,000,000,000,000,000,000,000E+47" },
   {0,0,0,0,0 }
 };
 
@@ -382,6 +564,30 @@ errno_test overflow_errno_tests[] = {
 
   /* A very long exponent field must be handled without integer overflow. */
   {__LINE__, "1E999999999999999999999", ERANGE, TEST_ALL, "Exponent field far beyond int range"},
+
+  /* --- Overflow driven by a long integer component ---
+     A written integer of __DECn_MAX_EXP__ digits is one digit too long for
+     the format, but the digit count alone does not decide it: 10^Emax is
+     representable while (10^Emax - 1) rounds up to 10^Emax ... which is not.
+     Both must be classified by the rounded value, and the overflow must set
+     ERANGE like any other. */
+  {__LINE__, NINES_D32_FIT, 0, TEST_D32, "D32 96-digit integer is not overflow"},
+  {__LINE__, NINES_D32_OVER, ERANGE, TEST_D32, "D32 97-digit integer rounds up to overflow"},
+  {__LINE__, NINES_D64_FIT, 0, TEST_D64, "D64 384-digit integer is not overflow"},
+  {__LINE__, NINES_D64_OVER, ERANGE, TEST_D64, "D64 385-digit integer rounds up to overflow"},
+  {__LINE__, NINES_D128_FIT, 0, TEST_D128, "D128 6144-digit integer is not overflow"},
+  {__LINE__, NINES_D128_OVER, ERANGE, TEST_D128, "D128 6145-digit integer rounds up to overflow"},
+
+  /* The same integers scaled down by one decade are comfortably in range. */
+  {__LINE__, NINES_D32_OVER "e-1", 0, TEST_D32, "D32 97-digit integer scaled by e-1"},
+  {__LINE__, NINES_D64_OVER "e-1", 0, TEST_D64, "D64 385-digit integer scaled by e-1"},
+  {__LINE__, NINES_D128_OVER "e-1", 0, TEST_D128, "D128 6145-digit integer scaled by e-1"},
+
+  /* 1E96 and 1E97 spelled out as 97- and 98-digit integers. */
+  {__LINE__, "1" Z10 Z10 Z10 Z10 Z10 Z10 Z10 Z10 Z10 "000000",
+   0, TEST_D32, "D32 1E96 written as a 97-digit integer is not overflow"},
+  {__LINE__, "1" Z10 Z10 Z10 Z10 Z10 Z10 Z10 Z10 Z10 "0000000",
+   ERANGE, TEST_D32, "D32 1E97 written as a 98-digit integer overflows"},
   {0, NULL, 0, 0, NULL},
 
   /* Underflow to zero should set errno to ERANGE */
@@ -459,6 +665,22 @@ endptr_test endptr_tests[] = {
 
   /* Long fully-valid tokens are consumed in their entirety. */
   {__LINE__, "9999999999999999999999999999999999999999", 40, TEST_ALL, "Long integer fully consumed"},
+
+  /* Long integer components are consumed whatever the value does: whether the
+     digits round in range, overflow, or get scaled by a fraction/exponent,
+     endptr must still land on the first non-numeric character. */
+  {__LINE__, NINES_D32_FIT, 96, TEST_ALL, "96-digit integer fully consumed"},
+  {__LINE__, NINES_D32_OVER, 97, TEST_ALL, "97-digit overflowing integer fully consumed"},
+  {__LINE__, NINES_D64_OVER, 385, TEST_ALL, "385-digit integer fully consumed"},
+  {__LINE__, NINES_D128_OVER, 6145, TEST_ALL, "6145-digit integer fully consumed"},
+  {__LINE__, NINES_D128_OVER "e-1", 6148, TEST_ALL, "6145-digit integer with exponent fully consumed"},
+  {__LINE__, NINES_D32_OVER "xyz", 97, TEST_ALL, "97-digit integer then letters"},
+  {__LINE__, "12345678901234567890123456789012345.6789", 40, TEST_ALL,
+   "Long integer with fraction fully consumed"},
+  {__LINE__, "12345678901234567890123456789012345.6789e+12", 44, TEST_ALL,
+   "Long integer with fraction and exponent fully consumed"},
+  {__LINE__, "00000000000012345678901234567890", 32, TEST_ALL,
+   "Leading zeroes and long integer fully consumed"},
 
   /* Leading whitespace is skipped; all five characters are consumed. */
   {__LINE__, "\f\v123", 5, TEST_ALL, "Form-feed and vertical-tab whitespace skipped"},


### PR DESCRIPTION
strtodN is a mess, these patches attempt to fix quite a few bugs, but not all of them.

AI assistance was used to create and update parts of the test program. It was not used to fix libdfp.